### PR TITLE
Save more column metadata to .json file, PlanNode.properties to {key:value}

### DIFF
--- a/src/objects.py
+++ b/src/objects.py
@@ -20,11 +20,15 @@ class FieldInTableHelper:
 @dataclasses.dataclass
 class Field:
     name: str = None
+    position: int = None
     is_index: bool = None
     indexes: List[str] = None
+    defined_width: int = None
+    avg_width: int = None
 
     def copy(self):
-        return Field(self.name, self.is_index, self.indexes.copy())
+        return Field(self.name, self.position, self.is_index, self.indexes.copy(),
+                     self.defined_width, self.avg_width)
 
 
 @dataclasses.dataclass

--- a/src/objects.py
+++ b/src/objects.py
@@ -114,7 +114,7 @@ class PlanNode:
         self.level: int = 0
         self.node_type: str = None
         self.name: str = None
-        self.properties: List[str] = []
+        self.properties = {}
         self.child_nodes: List[PlanNode] = []
 
         self.startup_cost: float = 0.0


### PR DESCRIPTION
Save more column metadata to .json file
---
    
    * Add column metadata:
      - position in the table
      - defined width (-1 indicating "unknown" for text, array, etc. types
        with unbound length)
      - average width collected by ANALYZE
    
    * Combined the table, column and index metadata retrieval sql and stop
      using the information_schema views for speed up.
    
      On my Macbook Pro, loading time of the system catalog and
      cost-validation model tables improved from 2 minutes to 200 ms.
      Loading the column width stats increased about 300 ms.

 Store PlanNode properties as {key: value} pairs instead of [str]
---
    
    - Hash bucket stats are broken up into separate entries as if they were
      saved in json, etc. format.
    
      e.g.:
    
      Buckets: 131072  Batches: 2  Memory Usage: 2525kB
    
      --> {
        'Hash Buckets': '131072', 'Hash Batches': '2', 'Peak Memory Usage': '2525'
      }
    
    - Other multi-item lines are stored with the first substring before ':'
      as the key and the rest as the value.
    
      e.g.:
    
      Hits: 261391  Misses: 1  Evictions: 0  Overflows: 0  Memory Usage: 1kB
      Worker 0:  Hits: 258575  Misses: 2  Evictions: 0  Overflows: 0  Memory Usage: 1kB
    
      --> {
        'Hits': '261391  Misses: 1  Evictions: 0  Overflows: 0  Memory Usage: 1kB',
        'Worker 0': 'Hits: 258575  Misses: 2  Evictions: 0  Overflows: 0  Memory Usage: 1kB'
      }
