### PR TITLE
add cost validation report interactive mode

### DIFF
--- a/src/actions/reports/cost.py
+++ b/src/actions/reports/cost.py
@@ -1,3 +1,5 @@
+import html
+import numpy as np
 import re
 from collections import namedtuple
 from collections.abc import Callable
@@ -10,11 +12,11 @@ from matplotlib import pyplot as plt
 from matplotlib import rcParams
 
 from collect import CollectResult
-from objects import Query, ScanNode, PlanNodeVisitor
+from objects import Query, PlanNode, ScanNode, PlanNodeVisitor, PlanPrinter
 from actions.report import AbstractReportAction
 
 
-PlotSeriesData = namedtuple('PlotSeriesData', ['fmt', 'x', 'cost', 'time_ms'])
+PlotSeriesData = namedtuple('PlotSeriesData', ['x', 'cost', 'time_ms', 'node'])
 
 
 @dataclass
@@ -37,10 +39,11 @@ class ChartSetSpec:
     series_label_suffix: Callable = None
     options: ChartOptions = field(default_factory=ChartOptions)
 
-    file_names: [str] = field(default_factory=list)
-    queries: (str) = field(default_factory=set)
-    plot_series: {str: list[str] } = field(default_factory=dict)
-    plot_series_data: { str: list[PlotSeriesData] } = field(default_factory=dict)
+    file_name: str = ''
+    queries: set[str] = field(default_factory=set)
+    series_data: {str: list[PlotSeriesData]} = field(default_factory=dict)
+    series_format: {str: str} = field(default_factory=dict)
+    series_details: {str: list[str]} = field(default_factory=dict)
 
 
 @dataclass
@@ -66,6 +69,28 @@ class PlanFeatures:
                 setattr(self, a, True)
 
 
+@dataclass(frozen=True)
+class PlanContext:
+    parent_query: Query
+    index: int
+    plan_tree: PlanNode
+
+    def get_query(self):
+        return self.parent_query.optimizations[self.index] if self.index else self.parent_query
+
+
+@dataclass(frozen=True)
+class NodeDetail:
+    plan_context: PlanContext
+    node_width: int
+
+    def get_query(self):
+        return self.plan_context.get_query()
+
+    def get_plan_tree(self):
+        return self.plan_context.plan_tree
+
+
 class PlanNodeCollectorContext:
     def __init__(self, plan_features):
         self.seq_scan_nodes: {str: list[ScanNode]} = {}
@@ -84,25 +109,28 @@ class PlanNodeCollectorContext:
 
 
 class PlanNodeCollector(PlanNodeVisitor):
-    def __init__(self, ctx, logger):
+    def __init__(self, ctx, plan_ctx, node_detail_map, logger):
         super().__init__()
         self.ctx = ctx
+        self.plan_ctx = plan_ctx
+        self.node_detail_map = node_detail_map
         self.logger = logger
         self.num_scans = 0
         self.depth = 0
+        self.scan_node_width_map = self.compute_scan_node_width(plan_ctx.get_query())
 
     def __enter(self):
         self.ctx.pf.__init__()
 
     def __exit(self):
         self.ctx.pf.has_single_scan_node = (self.num_scans == 1)
-        self.ctx.pf.has_no_condition_scan = (not self.ctx.pf.has_key_access_index
-                                             and not self.ctx.pf.has_scan_filter_index
-                                             and not self.ctx.pf.has_tfbr_filter_index
-                                             and not self.ctx.pf.has_table_filter_seqscan
-                                             and not self.ctx.pf.has_local_filter)
+        self.ctx.pf.has_no_condition_scan = not (self.ctx.pf.has_key_access_index
+                                                 or self.ctx.pf.has_scan_filter_index
+                                                 or self.ctx.pf.has_tfbr_filter_index
+                                                 or self.ctx.pf.has_table_filter_seqscan
+                                                 or self.ctx.pf.has_local_filter)
 
-    def visit_PlanNode(self, node):
+    def visit_plan_node(self, node):
         if self.depth == 0:
             self.__enter()
         self.depth += 1
@@ -113,7 +141,7 @@ class PlanNodeCollector(PlanNodeVisitor):
         if self.depth == 0:
             self.__exit()
 
-    def visit_ScanNode(self, node):
+    def visit_scan_node(self, node):
         if self.depth == 0:
             self.__enter()
         self.depth += 1
@@ -121,22 +149,29 @@ class PlanNodeCollector(PlanNodeVisitor):
 
         if int(node.nloops) > 0:
             table = node.table_alias or node.table_name
-            self.ctx.pf.has_local_filter = int(node.get_local_filter() != None)
+            node_width = self.scan_node_width_map.get(table)
+            # try postgres-generated number suffixed alias
+            if (not node_width and node.table_alias
+                and (m := re.fullmatch(f'({node.table_name})_\d+', node.table_alias))):
+                table = m.group(1)
+                node_width = self.scan_node_width_map.get(table)
+            # use the estimated width if still no avail (TAQO collector was not able to find
+            # matching table/field metadata)
+            if not node_width:
+                node_width = node.plan_width
+
+            self.node_detail_map[id(node)] = NodeDetail(self.plan_ctx, node_width)
+
             if node.is_seq_scan:
                 if table not in self.ctx.seq_scan_nodes:
                     self.ctx.seq_scan_nodes[table] = []
                 self.ctx.seq_scan_nodes[table].append(node)
-                self.ctx.pf.has_table_filter_seqscan |= int(node.get_remote_filter() != None)
+                self.set_seq_scan_node_features(self.ctx.pf, node)
             elif node.is_any_index_scan:
                 if table not in self.ctx.any_index_scan_nodes:
                     self.ctx.any_index_scan_nodes[table] = []
                 self.ctx.any_index_scan_nodes[table].append(node)
-                self.ctx.pf.has_key_access_index |= int(node.get_index_cond() != None)
-                self.ctx.pf.has_scan_filter_index |= int(node.get_remote_filter() != None)
-                self.ctx.pf.has_tfbr_filter_index |= int(node.get_remote_tfbr_filter() != None)
-                self.ctx.pf.has_no_filter_index |= (not self.ctx.pf.has_scan_filter_index
-                                                    and not self.ctx.pf.has_tfbr_filter_index
-                                                    and not self.ctx.pf.has_local_filter)
+                self.set_index_scan_node_features(self.ctx.pf, node)
             else:
                 self.logger.warn(f'Unknown ScanNode: node_type={node.node_type}')
 
@@ -146,20 +181,51 @@ class PlanNodeCollector(PlanNodeVisitor):
         if self.depth == 0:
             self.__exit()
 
+    @staticmethod
+    def set_seq_scan_node_features(feat, node):
+        feat.has_local_filter = int(node.get_local_filter() is not None)
+        feat.has_table_filter_seqscan |= int(node.get_remote_filter() is not None)
+
+    @staticmethod
+    def set_index_scan_node_features(feat, node):
+        feat.has_local_filter = int(node.get_local_filter()is not None)
+        feat.has_key_access_index |= int(node.get_index_cond()is not None)
+        feat.has_scan_filter_index |= int(node.get_remote_filter()is not None)
+        feat.has_tfbr_filter_index |= int(node.get_remote_tfbr_filter()is not None)
+        feat.has_no_filter_index |= not (feat.has_scan_filter_index
+                                         or feat.has_tfbr_filter_index
+                                         or feat.has_local_filter)
+
+    @staticmethod
+    def compute_scan_node_width(query):
+        scan_node_width_map = dict()
+        if not query or not query.tables:
+            return dict()
+        for t in query.tables:
+            width = 0
+            for f in t.fields:
+                width += f.avg_width or f.defined_width
+            scan_node_width_map[t.alias or t.name] = width
+        return scan_node_width_map
+
 
 class CostReport(AbstractReportAction):
     def __init__(self):
         super().__init__()
 
+        self.interactive = False
+
         self.report_location = f'report/{self.start_date}'
         self.image_folder = 'imgs'
 
         self.table_row_map: { str: float } = {}
-        self.node_projection_width_map: { str: int } = {}
+        self.node_detail_map: { int: NodeDetail } = {}
         self.scan_node_map: { str: { str: [ ScanNode ] } } = {}
         self.query_map: { str: (Query, PlanFeatures) } = {}
 
-        self.num_no_opt_queries = 0
+        self.num_plans: int = 0
+        self.num_invalid_cost_plans: int = 0
+        self.num_no_opt_queries: int = 0
 
 
     def get_image_path(self, file_name):
@@ -169,24 +235,33 @@ class CostReport(AbstractReportAction):
         self.report += f"a|image::{self.image_folder}/{file_name}[{title}]\n"
 
     @classmethod
-    def generate_report(cls, loq: CollectResult):
+    def generate_report(cls, loq: CollectResult, interactive):
         report = CostReport()
+        report.interactive = interactive
 
-        report.define_version(loq.db_version)
-        report.report_config(loq.config, "YB")
+        chart_specs = report.get_chart_specs()
 
-        report.report_model(loq.model_queries)
+        if interactive:
+            chart_specs = report.choose_chart_spec(chart_specs)
+        else:
+            report.define_version(loq.db_version)
+            report.report_config(loq.config, "YB")
+            report.report_model(loq.model_queries)
 
         for query in loq.queries:
             report.add_query(query)
 
-        report.logger.info(f"Queries processed: {len(loq.queries)}")
-        report.logger.warn(f"Queries without non-default plans: {report.num_no_opt_queries}")
+        report.logger.info(f"Processed {len(loq.queries)} queries  {report.num_plans} plans")
+        if report.num_no_opt_queries:
+            report.logger.warn(f"Queries without non-default plans: {report.num_no_opt_queries}")
+        if report.num_invalid_cost_plans:
+            report.logger.warn(f"Plans with invalid costs: {report.num_invalid_cost_plans}")
 
-        report.build_report()
-        report.build_xls_report()
+        report.collect_nodes_and_create_plots(chart_specs)
 
-        report.publish_report("cost")
+        if not interactive:
+            report.build_report(chart_specs)
+            report.publish_report("cost")
 
     def get_report_name(self):
         return "cost validation"
@@ -194,28 +269,41 @@ class CostReport(AbstractReportAction):
     def define_version(self, version):
         self.report += f"[VERSION]\n====\n{version}\n====\n\n"
 
+    def add_table_row_count(self, tables):
+        for t in tables:
+            self.table_row_map[t.name] = t.rows
+
+    def process_plans(self, ctx, parent_query, index):
+        query = parent_query.optimizations[index] if index else parent_query
+        plan = query.execution_plan
+        if not (ptree := plan.parse_plan()):
+            self.logger.warn(f"=== Failed to parse plan ===\n{plan.full_str}\n===")
+        else:
+            self.num_plans += 1
+            if ptree.has_valid_cost():
+                pctx = PlanContext(parent_query, index, ptree)
+                PlanNodeCollector(ctx, pctx, self.node_detail_map, self.logger).visit(ptree)
+            else:
+                self.num_invalid_cost_plans += 1
+                self.logger.warn(f"=== Skipping plan with invalid costs ===\n" \
+                                 f"hints: [{query.explain_hints}]\n" \
+                                 f"{plan.full_str}\n===")
+
     def add_query(self, query: Type[Query]):
         self.logger.debug(f'Processing query ({query.query_hash}): {query.query}...')
-        self.add_to_table_row_map(query.tables)
-
-        table_width_map = {}
-        for t in query.tables:
-            width = 0
-            for f in t.fields:
-                width += f.avg_width or f.defined_width
-            table_width_map[t.alias or t.name] = width
+        self.add_table_row_count(query.tables)
 
         pf = PlanFeatures()
         ctx = PlanNodeCollectorContext(pf)
 
-        self.process_plans(query.execution_plan, ctx)
+        self.process_plans(ctx, query, index=None)
 
         if not query.optimizations:
             self.num_no_opt_queries += 1
         else:
-            for plan in query.optimizations:
-                if plan.execution_plan and plan.execution_plan.full_str:
-                    self.process_plans(plan.execution_plan, ctx)
+            for ix, opt in enumerate(query.optimizations):
+                if opt.execution_plan and opt.execution_plan.full_str:
+                    self.process_plans(ctx, query, ix)
                     pf.merge(ctx.pf)
 
         pf.is_single_table = len(query.tables) == 1
@@ -231,8 +319,6 @@ class CostReport(AbstractReportAction):
             self.scan_node_map[query.query][table] += node_list
 
             for node in node_list:
-                self.node_projection_width_map[id(node)] = (table_width_map.get(node.table_alias)
-                                                            or table_width_map[node.table_name])
                 self.logger.debug(
                     '  '.join(
                         filter(lambda prop: prop, [
@@ -252,10 +338,10 @@ class CostReport(AbstractReportAction):
         self._end_source()
         self._end_collapsible()
 
-    def report_plot_series(self, plot_series):
+    def report_plot_series_details(self, plot_series_details):
         self._start_collapsible("Plot series")
         self._start_source(["text"])
-        for series_label, conditions in sorted(plot_series.items()):
+        for series_label, conditions in sorted(plot_series_details.items()):
             self.report += f"{series_label}\n"
             for cond in sorted(conditions):
                 self.report += f"    {cond}\n"
@@ -265,203 +351,286 @@ class CostReport(AbstractReportAction):
     def report_plot_series_data(self, plot_series_data, data_labels):
         self._start_collapsible("Plot data")
         self._start_source(["text"])
-        if len(plot_series_data):
+        if plot_series_data:
             self.report += f"{data_labels}\n"
             for series_label, data_points in plot_series_data.items():
                 self.report += f"{series_label}\n"
-                for tup in zip(data_points.x, data_points.cost, data_points.time_ms):
-                    self.report += f"    {tup}\n"
+                for x, cost, time_ms, _ in data_points:
+                    self.report += f"    ({x}, {cost}, {time_ms})\n"
         self._end_source()
         self._end_collapsible()
 
-    def build_report(self):
+    def build_report(self, chart_specs):
         self.report += "\n== Scan Nodes\n"
 
-        chart_specs = []
-
-        chart_specs.append(ChartSetSpec(
-            'No filter full scans by output rows (width &lt; 2000)',
-            'Output rows', 'Estimated cost', 'Execution time [ms]',
-            lambda query: True,
-            lambda node: (node.has_no_filter() and not node.get_index_cond()
-                          and self.get_node_width(node) < 2000),
-            lambda node: int(node.rows),
-            series_label_suffix = (lambda node: f' {node.index_name or node.table_name} width={self.get_node_width(node)}'),
-        ))
-
-        chart_specs.append(ChartSetSpec(
-            'No filter full scans by output rows (width &ge; 2000)',
-            'Output rows', 'Estimated cost', 'Execution time [ms]',
-            lambda query: True,
-            lambda node: (node.has_no_filter() and not node.get_index_cond()
-                          and self.get_node_width(node) >= 2000),
-            lambda node: int(node.rows),
-            series_label_suffix = (lambda node: f' {node.index_name or node.table_name} width={self.get_node_width(node)}'),
-        ))
-
-        chart_specs.append(ChartSetSpec(
-            'No filter full scans by output rows (Index Only Scans, width &lt; 2000)',
-            'Output rows', 'Estimated cost', 'Execution time [ms]',
-            lambda query: True,
-            lambda node: (node.has_no_filter() and not node.get_index_cond()
-                          and node.is_index_only_scan and self.get_node_width(node) < 2000),
-            lambda node: int(node.rows),
-            series_label_suffix = (lambda node: f' width={self.get_node_width(node)}'),
-        ))
-
-        chart_specs.append(ChartSetSpec(
-            'No filter full scans by output rows (Seq Scans, width &lt; 2000)',
-            'Output rows', 'Estimated cost', 'Execution time [ms]',
-            lambda query: True,
-            lambda node: (node.has_no_filter() and not node.get_index_cond()
-                          and node.is_seq_scan and self.get_node_width(node) < 2000),
-            lambda node: int(node.rows),
-            series_label_suffix = (lambda node: f' {node.table_name} width={self.get_node_width(node)}'),
-        ))
-
-        chart_specs.append(ChartSetSpec(
-            'No filter index scans and seq scans, simple condition on single key',
-            'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
-            lambda query: self.nofilter_indexscan_query(query),
-            lambda node: (node.table_name != 't1000000m'
-                          and (node.is_seq_scan
-                               or self.has_simple_index_cond(node, index_cond_only=True))),
-            self.get_actual_node_selectivity,
-            series_label_suffix = (lambda node: f' {node.index_name or node.table_name}:width={self.get_node_width(node)}'),
-        ))
-
-        chart_specs.append(ChartSetSpec(
-            'Index scan nodes with literal IN-list',
-            'In/out row count ratio', 'Actual-row-count adjusted cost', 'Execution time [ms]',
-            lambda query: True,
-            lambda node: (self.has_inlist_index_cond(node, parameterized=False)
-                          and node.has_no_filter()),
-            self.get_actual_node_selectivity,
-            series_label_suffix = (lambda node: f'{ node.index_name}:width={self.get_node_width(node)}:items={self.count_inlist_items(node.get_index_cond()[0])}'),
-            options=ChartOptions(adjust_cost_by_actual_rows=True)
-        ))
-
-        chart_specs.append(ChartSetSpec(
-            'Index scan nodes with parameterized IN-list (BNL)',
-            'In/out row count ratio', 'Actual-row-count adjusted cost', 'Execution time [ms]',
-            lambda query: True,
-            lambda node: (self.has_inlist_index_cond(node, parameterized=True)
-                          and node.has_no_filter()),
-            self.get_actual_node_selectivity,
-            series_label_suffix = (lambda node: f'{ node.index_name}:width={self.get_node_width(node)} loops={node.nloops}'),
-            options=ChartOptions(adjust_cost_by_actual_rows=True, multipy_by_nloops=True)
-        ))
-
-        chart_specs.append(ChartSetSpec(
-            'Composite key index scans',
-            'In/out row count ratio', 'Actual-row-count adjusted cost', 'Execution time [ms]',
-            lambda query: 't1000000m' in query,
-            lambda node: (not node.get_local_filter()
-                          and ((node.is_seq_scan
-                                and (not (expr := node.get_remote_filter())
-                                     or self.is_simple_literal_condition(expr)))
-                               or self.has_simple_index_cond(node, index_cond_only=True))),
-            self.get_actual_node_selectivity,
-            series_label_suffix = (lambda node: f'{ node.index_name}'),
-            options=ChartOptions(adjust_cost_by_actual_rows=True, multipy_by_nloops=True)
-        ))
-
-        chart_specs.append(ChartSetSpec(
-            'Index scans with remote index filter and seq scans, simple condition',
-            'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
-            lambda query: self.scanfilter_indexscan_query(query),
-            lambda node: (node.table_name != 't1000000m'
-                          and (node.is_seq_scan
-                               or ((expr := node.get_remote_filter())
-                                   and self.is_simple_literal_condition(expr))
-                               or ((expr := node.get_remote_tfbr_filter())
-                                   and self.is_simple_literal_condition(expr)))),
-            self.get_actual_node_selectivity,
-            series_label_suffix = (lambda node: f' {node.index_name or node.table_name}:width={self.get_node_width(node)}'),
-        ))
-
-        self.collect_nodes_and_create_plots(chart_specs)
-
-        for spec in chart_specs:
-            self.report += f"=== {spec.title}\n"
-            self._start_table("3")
-            self.report += f"|{spec.xlabel} - {spec.ylabel1}"
-            self.report += f"|{spec.xlabel} - {spec.ylabel2}"
-            self.report += f"|{spec.ylabel1} - {spec.ylabel2}\n"
-            self.add_image(spec.file_names[0], '{spec.ylabel1},align=\"center\"')
-            self.add_image(spec.file_names[1], '{spec.ylabel2},align=\"center\"')
-            self.add_image(spec.file_names[2], '{spec.ylabel1} - {spec.ylabel2},align=\"center\"')
+        for i, spec in enumerate(chart_specs):
+            title = html.escape(spec.title)
+            self.report += f"=== {i}. {title}\n"
+            self._start_table("1")
+            self.add_image(spec.file_name, '{title},align=\"center\"')
             self._end_table()
 
             self._start_table()
             self._start_table_row()
             self.report_queries(spec.queries)
-            self.report_plot_series(spec.plot_series)
-            self.report_plot_series_data(spec.plot_series_data,
-                                         ('{spec.xlabel}', '{spec.ylabel1}', 'spec.ylabel2'))
+            self.report_plot_series_details(spec.series_details)
+            self.report_plot_series_data(spec.series_data,
+                                         (f'{html.escape(spec.xlabel)}',
+                                          f'{html.escape(spec.ylabel1)}',
+                                          f'{html.escape(spec.ylabel2)}'))
             self._end_table_row()
             self._end_table()
 
+    __spcrs = " !\"#$%&'()*+,./:;<=>?[\\]^`{|}~"
+    __xtab = str.maketrans(" !\"#$%&'()*+,./:;<=>?ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^`{|}~",
+                           "---------------------abcdefghijklmnopqrstuvwxyz---------")
+    def make_file_name(self, str_list: list[str]):
+        return f"{'-'.join(s.strip(self.__spcrs).translate(self.__xtab) for s in str_list)}.png"
 
-    def build_xls_report(self):
-        pass
+    def create_node_plots(self, spec):
+        title = spec.title
+        xy_labels = [ spec.xlabel, spec.ylabel1, spec.ylabel2 ]
 
-    def add_to_table_row_map(self, tables):
-        for t in tables:
-            self.table_row_map[t.name] = t.rows
+        rcParams['font.family'] = 'serif'
+        rcParams['font.size'] = 8
 
-    def create_node_plots(self, plot_series_data,
-                          title, xvalue_idx, xlabel, yvalue_idx, ylabel,
-                          legend=False):
-        file_name = self.make_file_name([title, xlabel, ylabel])
+        fig, axs = plt.subplots(1, 3, figsize=(24, 8),
+                                layout='constrained')
+#                                layout='none' if self.interactive else 'constrained')
+        fig.suptitle(title, fontsize='xx-large')
 
-        plt.xlabel(xlabel)
-        plt.ylabel(ylabel)
+        chart_ix = [(1, 2), (0, 2), (0, 1)] # cost-time, x-time, x-cost
+        no_data = not spec.series_data
+        for i in range(len(chart_ix)):
+            ax = axs[i]
+            x, y = chart_ix[i]
+            xlabel = xy_labels[x]
+            ylabel = xy_labels[y]
 
-        if no_data := (len(plot_series_data) == 0):
-            plt.text(0.5, 0.5, "NO DATA", size=50, family='sans serif', rotation=30.,
-                     ha="center", va="center", alpha=0.4,
-                     )
+            ax.set_box_aspect(1)
+            ax.set_title(f'{xlabel} - {ylabel}', fontsize='x-large')
+            ax.set_xlabel(xlabel)
+            ax.set_ylabel(ylabel)
+            if no_data:
+                ax.text(0.5, 0.5, "NO DATA", size=50, family='sans serif', rotation=30.,
+                        ha="center", va="center", alpha=0.4)
 
-        for (series_label, data_points) in plot_series_data.items():
-            plt.plot(data_points[xvalue_idx],
-                     data_points[yvalue_idx],
-                     data_points.fmt,
-                     label=series_label,
-                     alpha=0.35)
+        for series_label, data_points in spec.series_data.items():
+            transposed_data = np.split(np.array(data_points).transpose(),
+                                       len(PlotSeriesData._fields))
+            for i in range(len(chart_ix)):
+                x, y = chart_ix[i]
+                ax = axs[i]
+                ax.plot(transposed_data[x][0],
+                        transposed_data[y][0],
+                        spec.series_format[series_label],
+                        label=series_label,
+                        alpha=0.35,
+                        picker=self.line_picker)
 
-        if legend:
-            plt.legend(fontsize='xx-small',
-                       ncols=int((len(plot_series_data.keys())+39)/40.0))
+                ax.set_xbound(lower=0.0)
+                ax.set_ybound(lower=0.0)
 
-        plt.savefig(self.get_image_path(file_name), dpi=600 if not no_data else 100)
-        plt.close()
-        return file_name
-
-    def process_plans(self, plan, ctx):
-        if not (ptree := plan.parse_plan()):
-            self.logger.warn(f"=== Failed to parse plan ===\n{plan.full_str}\n===")
+        if self.interactive:
+            self.show_charts_and_handle_events(spec, fig, axs)
         else:
-            if ptree.has_valid_cost():
-                PlanNodeCollector(ctx, self.logger).visit(ptree)
-            else:
-                self.logger.warn(f"=== Skipping plan with invalid costs ===\n{plan.full_str}\n===")
+            # show the legend on the last subplot
+            axs[-1].legend(fontsize='xx-small', ncols=int((len(spec.series_data.keys())+39)/40.0))
+            spec.file_name = self.make_file_name([title, xlabel])
+            plt.savefig(self.get_image_path(spec.file_name), dpi=450 if not no_data else 50)
 
-    def nofilter_indexscan_query(self, query_str):
-        (q, pf) = self.query_map.get(query_str)
+        plt.close()
+
+    def get_node_table_rows(self, node):
+        return float(self.table_row_map.get(node.table_name))
+
+    def get_node_width(self, node):
+        return int(self.node_detail_map[id(node)].node_width)
+
+    def get_actual_node_selectivity(self, node):
+        table_rows = self.get_node_table_rows(node)
+        return float(0 if not table_rows or table_rows == 0 else float(node.rows) / table_rows)
+
+    def collect_nodes_and_create_plots(self, specs: list[ChartSetSpec]):
+        self.logger.debug(f'Collecting plot data points...')
+
+        for query_str, table_node_list_map in self.scan_node_map.items():
+            for table, node_list in table_node_list_map.items():
+                for node in node_list:
+                    for spec in specs:
+                        if not spec.query_filter(query_str) or not spec.node_filter(node):
+                            continue
+
+                        spec.queries.add(query_str)
+
+                        series_label = ''
+                        if node.is_seq_scan:
+                            series_label += f'Seq Scan'
+                        elif node.is_any_index_scan:
+                            series_label += ''.join([
+                                f"{node.node_type}",
+                                ' Backward' if node.is_backward else '',
+                            ])
+                        else:
+                            series_label = node.name
+
+                        series_label += str(spec.series_label_suffix(node)
+                                            if spec.series_label_suffix else '')
+
+                        multiplier = (int(node.nloops)
+                                      if spec.options.multipy_by_nloops else 1)
+
+                        xdata = round(float(spec.x_getter(node)), 3)
+                        cost = round(multiplier * float(node.get_actual_row_adjusted_cost()
+                                                        if spec.options.adjust_cost_by_actual_rows
+                                                        else node.total_cost), 3)
+                        time_ms = round(float(node.total_ms) * multiplier, 3)
+
+                        if series_label not in spec.series_data:
+                            spec.series_data[series_label] = list()
+                            spec.series_details[series_label] = set()
+
+                        query, _ = self.query_map.get(query_str)
+                        spec.series_data[series_label].append(
+                            PlotSeriesData(xdata, cost, time_ms, node))
+
+                        cond = node.get_search_condition_str(with_label=True)
+                        spec.series_details[series_label].add(f"{cond}" if cond
+                                                              else "(No Search Condition)")
+
+
+        colors = [ 'b', 'g', 'r', 'c', 'm', 'y', 'k' ]
+        marker_style = [ 'o', '8', 's', 'p', '*', '+', 'x', 'd',
+                    'v', '^', '<', '>', '1', '2', '3', '4',
+                    'P', 'h', 'H', 'X', 'D', '|', '_']
+        line_style = [ '-', '--', '-.', ':' ]
+
+        for spec in specs:
+            for i, (series_label, node_data) in enumerate(spec.series_data.items()):
+                node_data.sort(key=itemgetter(0,2,1)) # xdata,time,cost
+
+                fmt = colors[ i % len(colors) ]
+                fmt += marker_style[ i % len(marker_style) ]
+
+                if re.search('Seq Scan', series_label):
+                    fmt += ':'
+                elif re.search('Index Scan.*_pkey', series_label):
+                    fmt += '-'
+                elif re.search('Index Scan', series_label):
+                    fmt += '-.'
+                elif re.search('Index Only Scan', series_label):
+                    fmt += '--'
+                else:
+                    fmt += ':'
+                spec.series_format[series_label] = fmt
+
+            self.create_node_plots(spec)
+
+    def choose_chart_spec(self, chart_specs):
+        choices = '\n'.join([ f'{n}: {s.title}' for n, s in enumerate(chart_specs) ])
+        while True:
+            try:
+                response = int(input(f'{choices}\n[0-{len(chart_specs)-1}] --> '))
+                if response < 0 or response >= len(chart_specs):
+                    raise ValueError
+                break
+            except ValueError:
+                print(f"*** Enter a number in range [0..{len(chart_specs)-1}] ***")
+                response = -1
+        return [chart_specs[int(response)]]
+
+    @staticmethod
+    def line_picker(line, event):
+        if event.xdata is None:
+            return False, dict()
+        ax = event.inaxes
+        [x], [y] = np.split(ax.transLimits.transform(line.get_xydata()).T, 2)
+        event_x, event_y = ax.transLimits.transform((event.xdata, event.ydata))
+        maxd = 0.02
+        d = np.sqrt((x - event_x)**2 + (y - event_y)**2)
+        # print(f'line={line}\n' \
+        #       f'x={x}\ny={y}\n' \
+        #       f'event_x={event_x} event_y={event_y}\n' \
+        #       f'd={d}\n' \
+        #       f'np.nonzero(d <= maxd)={np.nonzero(d <= maxd)}')
+        ind, = np.nonzero(d <= maxd)
+
+        if len(ind):
+            pickx = line.get_xdata()[ind]
+            picky = line.get_ydata()[ind]
+            props = dict(line=line, ind=ind, pickx=pickx, picky=picky,
+                         axx=event_x, axy=event_y)
+            return True, props
+        else:
+            return False, dict()
+
+    def show_charts_and_handle_events(self, spec, fig, axs):
+        def on_pick(event):
+            ann = anns[id(event.mouseevent.inaxes)]
+            series = event.line.get_label()
+            series_data = spec.series_data[series][event.ind[0]]
+            node = series_data.node
+            node_detail = self.node_detail_map[id(node)]
+
+            modifiers = event.mouseevent.modifiers
+            if 'alt' in modifiers:
+                ann.set_text(f'{PlanPrinter.build_plan_tree_str(node_detail.get_plan_tree())}')
+            elif 'shift' in modifiers:
+                query = node_detail.get_query()
+                ann.set_text(f'{query.query_hash}\n{query.query}')
+            else:
+                ann.set_text(f'{series}\n{node.name}\n'
+                             f'{node.get_estimate_str()}\n{node.get_actual_str()}\n'
+                             f'{node.get_search_condition_str(with_label=True)}')
+
+            ann.xy = event.artist.get_xydata()[event.ind][0]
+            ann.xyann = ((event.axx - 0.5)*(-200) - 120, (event.axy - 0.5)*(-200) + 40)
+
+            ann.set_visible(True)
+            fig.canvas.draw_idle()
+
+        def on_button_release(event):
+            if 'cmd' not in event.modifiers:
+                hide_all_annotations()
+
+        def hide_all_annotations():
+            redraw = False
+            for ann in anns.values():
+                redraw |= ann.get_visible()
+                ann.set_visible(False)
+                if redraw:
+                    fig.canvas.draw_idle()
+
+        anns = dict()
+        for ax in axs:
+            anns[id(ax)] = ax.annotate("", xy=(0, 0),
+                                       textcoords="offset points", xytext=(0, 0),
+                                       bbox=dict(boxstyle="round", fc="w"),
+                                       arrowprops=dict(arrowstyle="->"))
+            ann = anns[id(ax)]
+            ann.set_wrap(True)
+            ann.set_zorder(8)
+
+        hide_all_annotations()
+        fig.canvas.mpl_connect('pick_event', on_pick)
+        fig.canvas.mpl_connect('button_release_event', on_button_release)
+        plt.show()
+
+    def no_filter_indexscan_query(self, query_str):
+        _, pf = self.query_map.get(query_str)
         return pf.has_no_filter_index if pf else False
 
-    def scanfilter_indexscan_query(self, query_str):
-        (q, pf) = self.query_map.get(query_str)
+    def scan_filter_indexscan_query(self, query_str):
+        _, pf = self.query_map.get(query_str)
         return pf.has_scan_filter_index if pf else False
 
     def tfbr_filter_indexscan_query(self, query_str):
-        (q, pf) = self.query_map.get(query_str)
-        return pf.has_tfbr_filter_index if q else False
+        _, pf = self.query_map.get(query_str)
+        return pf.has_tfbr_filter_index if pf else False
 
     def local_filter_query(self, query_str):
-        (q, pf) = self.query_map.get(query_str)
-        return pf.has_local_filter if q else False
+        _, pf = self.query_map.get(query_str)
+        return pf.has_local_filter if pf else False
 
     @staticmethod
     def is_simple_literal_condition(expr):
@@ -498,115 +667,124 @@ class CostReport(AbstractReportAction):
                 and (parameterized is None
                      or parameterized == (index_cond.find('$', eq_any_start, eq_any_end) > 0)))
 
-    def get_node_table_rows(self, node):
-        return float(self.table_row_map.get(node.table_name))
-
-    def get_node_width(self, node):
-        return int(self.node_projection_width_map[id(node)])
-
-    def get_actual_node_selectivity(self, node):
-        table_rows = self.get_node_table_rows(node)
-        return float(0 if not table_rows or table_rows == 0 else float(node.rows) / table_rows)
-
-    __spcrs = " !\"#$%&'()*+,./:;<=>?[\\]^`{|}~"
-    __xtab = str.maketrans(" !\"#$%&'()*+,./:;<=>?ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^`{|}~",
-                           "---------------------abcdefghijklmnopqrstuvwxyz---------")
-    def make_file_name(self, str_list: list[str]):
-        return f"{'-'.join(s.strip(self.__spcrs).translate(self.__xtab) for s in str_list)}.png"
-
-    def collect_nodes_and_create_plots(self, specs: list[ChartSetSpec]):
-        self.logger.debug(f'Collecting plot data points...')
-        plot_data = []
-        for _ in range(len(specs)):
-            plot_data.append({})
-
-        for query_str, table_node_list_map in self.scan_node_map.items():
-            for table, node_list in table_node_list_map.items():
-                for node in node_list:
-                    for si, spec in enumerate(specs):
-                        if not spec.query_filter(query_str) or not spec.node_filter(node):
-                            continue
-
-                        spec.queries.add(query_str)
-
-                        series_label = ''
-                        if node.is_seq_scan:
-                            series_label += f'Seq Scan'
-                        elif node.is_any_index_scan:
-                            series_label += ''.join([
-                                f"{node.node_type}",
-                                ' Backward' if node.is_backward else '',
-                            ])
-                        else:
-                            series_label = node.name
-
-                        series_label += str(spec.series_label_suffix(node)
-                                            if spec.series_label_suffix else '')
-
-                        if series_label not in plot_data[si]:
-                            plot_data[si][series_label] = []
-                            spec.plot_series[series_label] = set()
-
-                        multiplier = (int(node.nloops)
-                                      if spec.options.multipy_by_nloops else 1)
-
-                        cost = multiplier * float(node.get_actual_row_adjusted_cost()
-                                                  if spec.options.adjust_cost_by_actual_rows
-                                                  else node.total_cost)
-
-                        time_ms = float(node.total_ms) * multiplier
-
-                        plot_data[si][series_label].append((float(spec.x_getter(node)),
-                                                            cost, time_ms))
-
-                        cond = node.get_search_condition_str(with_label=True)
-                        spec.plot_series[series_label].add(f"{cond}" if cond
-                                                           else "(No Search Condition)")
-
-
-        colors = [ 'b', 'g', 'r', 'c', 'm', 'y', 'k' ]
-        marker_style = [ 'o', '8', 's', 'p', '*', '+', 'x', 'd',
-                    'v', '^', '<', '>', '1', '2', '3', '4',
-                    'P', 'h', 'H', 'X', 'D', '|', '_']
-        line_style = [ '-', '--', '-.', ':' ]
-
-        rcParams['font.family'] = 'serif'
-        rcParams['font.size'] = 6
-
-        for si, spec in enumerate(specs):
-            for i, (series_label, node_data) in enumerate(plot_data[si].items()):
-                node_data.sort(key=itemgetter(0,2,1)) # xdata,time,cost
-                xdata = []
-                cost = []
-                time_ms = []
-                for (x, c, t) in node_data:
-                    xdata.append(x)
-                    cost.append(c)
-                    time_ms.append(t)
-
-                fmt = colors[ i % len(colors) ]
-                fmt += marker_style[ i % len(marker_style) ]
-
-                # fmt += line_style[ i % len(line_style) ]
-                if re.search('Seq Scan', series_label):
-                    fmt += ':'
-                elif re.search('Index Scan.*_pkey', series_label):
-                    fmt += '-'
-                elif re.search('Index Scan', series_label):
-                    fmt += '-.'
-                elif re.search('Index Only Scan', series_label):
-                    fmt += '--'
-                else:
-                    fmt += ':'
-
-                spec.plot_series_data[series_label] = PlotSeriesData(fmt, xdata, cost, time_ms)
-
-            spec.file_names.append(self.create_node_plots(spec.plot_series_data, spec.title,
-                                                          1, spec.xlabel, 2, spec.ylabel1))
-            spec.file_names.append(self.create_node_plots(spec.plot_series_data, spec.title,
-                                                          1, spec.xlabel, 3, spec.ylabel2,
-                                                          legend=True))
-            spec.file_names.append(self.create_node_plots(spec.plot_series_data, spec.title,
-                                                          2, spec.ylabel1, 3, spec.ylabel2))
-
-            self.logger.debug(f'file_names={spec.file_names}')
+    def get_chart_specs(self):
+        return [
+            ChartSetSpec(
+                'No filter full scans by output rows (width < 2000)',
+                'Output rows', 'Estimated cost', 'Execution time [ms]',
+                lambda query: True,
+                lambda node: (node.has_no_filter() and not node.get_index_cond()
+                              and self.get_node_width(node) < 2000),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node: f' {node.index_name or node.table_name} width={self.get_node_width(node)}'),
+            ),
+            ChartSetSpec(
+                'No filter full scans by output rows (width >= 2000)',
+                'Output rows', 'Estimated cost', 'Execution time [ms]',
+                lambda query: True,
+                lambda node: (node.has_no_filter() and not node.get_index_cond()
+                              and self.get_node_width(node) >= 2000),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node: f' {node.index_name or node.table_name} width={self.get_node_width(node)}'),
+            ),
+            ChartSetSpec(
+                'No filter full scans by output rows (Index Only Scans, width < 2000)',
+                'Output rows', 'Estimated cost', 'Execution time [ms]',
+                lambda query: True,
+                lambda node: (node.has_no_filter() and not node.get_index_cond()
+                              and node.is_index_only_scan and self.get_node_width(node) < 2000),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node: f' width={self.get_node_width(node)}'),
+            ),
+            ChartSetSpec(
+                'No filter full scans by output rows (Seq Scans, width < 2000)',
+                'Output rows', 'Estimated cost', 'Execution time [ms]',
+                lambda query: True,
+                lambda node: (node.has_no_filter() and not node.get_index_cond()
+                              and node.is_seq_scan and self.get_node_width(node) < 2000),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node: f' {node.table_name} width={self.get_node_width(node)}'),
+            ),
+            ChartSetSpec(
+                'No filter index scans and seq scans, simple condition on single key',
+                'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
+                lambda query: self.no_filter_indexscan_query(query),
+                lambda node: (node.table_name != 't1000000m'
+                              and (node.is_seq_scan
+                                   or self.has_simple_index_cond(node, index_cond_only=True))),
+                self.get_actual_node_selectivity,
+                series_label_suffix=(lambda node: f' {node.index_name or node.table_name}:width={self.get_node_width(node)}'),
+            ),
+            ChartSetSpec(
+                'Index scan nodes with literal IN-list',
+                'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
+                lambda query: True,
+                lambda node: (self.has_inlist_index_cond(node, parameterized=False)
+                              and node.has_no_filter()
+                              and float(node.rows) > 0),
+                self.get_actual_node_selectivity,
+                series_label_suffix=(lambda node: f'{ node.index_name}:width={self.get_node_width(node)}:items={self.count_inlist_items(node.get_index_cond()[0])}'),
+                options=ChartOptions(adjust_cost_by_actual_rows=False)
+            ),
+            ChartSetSpec(
+                'Index scan nodes with literal IN-list (adjusted costs)',
+                'In/out row count ratio', 'Actual-row-count adjusted cost', 'Execution time [ms]',
+                lambda query: True,
+                lambda node: (self.has_inlist_index_cond(node, parameterized=False)
+                              and node.has_no_filter()
+                              and float(node.rows) > 0),
+                x_getter=self.get_actual_node_selectivity,
+                series_label_suffix=(lambda node: f'{ node.index_name}:width={self.get_node_width(node)}:items={self.count_inlist_items(node.get_index_cond()[0])}'),
+                options=ChartOptions(adjust_cost_by_actual_rows=True)
+            ),
+            ChartSetSpec(
+                'Index scan nodes with parameterized IN-list (BNL)',
+                'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
+                lambda query: True,
+                lambda node: (self.has_inlist_index_cond(node, parameterized=True)
+                              and node.has_no_filter()
+                              # catch fraction of rows less than 0.001
+                              and float(node.rows) > 0 or int(node.nloops) > 1),
+                x_getter=self.get_actual_node_selectivity,
+                series_label_suffix=(lambda node: f'{ node.index_name}:width={self.get_node_width(node)} loops={node.nloops}'),
+                options=ChartOptions(adjust_cost_by_actual_rows=False, multipy_by_nloops=True)
+            ),
+            ChartSetSpec(
+                'Index scan nodes with parameterized IN-list (BNL, adjusted costs)',
+                'In/out row count ratio', 'Actual-row-count adjusted cost', 'Execution time [ms]',
+                lambda query: True,
+                lambda node: (self.has_inlist_index_cond(node, parameterized=True)
+                              and node.has_no_filter()
+                              and float(node.rows) > 0 or int(node.nloops) > 1),
+                x_getter=self.get_actual_node_selectivity,
+                series_label_suffix=(lambda node: f'{ node.index_name}:width={self.get_node_width(node)} loops={node.nloops}'),
+                options=ChartOptions(adjust_cost_by_actual_rows=True, multipy_by_nloops=True)
+            ),
+            ChartSetSpec(
+                'Composite key index scans',
+                'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
+                lambda query: 't1000000m' in query,
+                lambda node: (not node.get_local_filter()
+                              and ((node.is_seq_scan
+                                    and (not (expr := node.get_remote_filter())
+                                         or self.is_simple_literal_condition(expr)))
+                                   or self.has_simple_index_cond(node, index_cond_only=True))
+                              and float(node.rows) > 0),
+                x_getter=self.get_actual_node_selectivity,
+                series_label_suffix=(lambda node: f'{ node.index_name} loops={node.nloops}'),
+            ),
+            ChartSetSpec(
+                'Index scans with remote index filter and seq scans, simple condition',
+                'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
+                lambda query: self.scan_filter_indexscan_query(query),
+                lambda node: (node.table_name != 't1000000m'
+                              and (node.is_seq_scan
+                                   or ((expr := node.get_remote_filter())
+                                       and self.is_simple_literal_condition(expr))
+                                   or ((expr := node.get_remote_tfbr_filter())
+                                       and self.is_simple_literal_condition(expr)))
+                              and float(node.rows) > 0),
+                x_getter=self.get_actual_node_selectivity,
+                series_label_suffix=(lambda node: f' {node.index_name or node.table_name}:width={self.get_node_width(node)} loops={node.nloops}'),
+            ),
+        ]

--- a/src/runner.py
+++ b/src/runner.py
@@ -69,9 +69,11 @@ if __name__ == "__main__":
                         help='Configuration file path')
 
     parser.add_argument('--type',
-                        help='Report type - taqo, regression, comparison or selectivity')
+                        help='Report type - taqo, score, regression, comparison, selectivity or cost')
 
-    # TAQO or Comparison
+    # report mode flags
+
+    # TAQO, Score, Comparison or Cost (--pg-results optional for TAQO, N/A for Cost)
     parser.add_argument('--results',
                         default=None,
                         help='TAQO/Comparison: Path to results with optimizations for YB')
@@ -111,6 +113,14 @@ if __name__ == "__main__":
     parser.add_argument('--stats-analyze-results',
                         default=None,
                         help='Results with table analyze and enabled statistics and EXPLAIN ANALYZE')
+
+    # Cost
+    parser.add_argument('--interactive',
+                        action=argparse.BooleanOptionalAction,
+                        default=False,
+                        help='Popup an interactive chart then quit')
+
+    # collect mode flags
 
     parser.add_argument('--ddl-prefix',
                         default="",
@@ -206,6 +216,8 @@ if __name__ == "__main__":
 
     parser.add_argument('--output',
                         help='Output JSON file name in report folder, [.json] will be added')
+
+    # collect/report mode common flags
 
     parser.add_argument('--clear',
                         action=argparse.BooleanOptionalAction,
@@ -361,6 +373,6 @@ if __name__ == "__main__":
                                               ta_analyze_queries, stats_queries, stats_analyze_queries)
         elif args.type == "cost":
             yb_queries = loader.get_queries_from_previous_result(args.results)
-            CostReport.generate_report(yb_queries)
+            CostReport.generate_report(yb_queries, args.interactive)
         else:
             raise AttributeError(f"Unknown test type defined {config.test}")


### PR DESCRIPTION
* add cost report interactive chart mode (single standalone chartset)
  - add --interactive flag to the cost report type, which then show a prompt to choose a chartset.
  - clicking on a data point shows the data series, plan node name along with the estimates and actuals, the index & filter conditions associated to the node.
  - the annotation stays there after button release with alt+click
  - shift+click shows the query
  - option+click shows the plan

  limitations:
    - the annotation may be obstructed by clipping or goes beind other charts/"artists"
    - shows only one of the data points/series when there are multiple candidates

* combine 3 charts in each chartset to a single figure

* clean up
   - rearrange charts in each chartset to cost-time, xdata-time, xdata-cost
   - move out fmt from PlotSeriesData tuple
   - print plan in invalid cost warning
   - move chart specs to the bottom
   - plan/node feature collection minor refactoring
   - streamline data point handling. use numpy transpose store tuple array in the ChartSpec

* add PlanNode level and property printing options
