### PR TITLE
Fixes and enhancements to PlanNode and cost report

### DIFF
--- a/src/actions/report.py
+++ b/src/actions/report.py
@@ -75,10 +75,11 @@ class AbstractReportAction:
     def _end_table(self):
         self.report += "|===\n"
 
-    def _start_source(self, additional_tags=None):
+    def _start_source(self, additional_tags=None, linenums=True):
         tags = f",{','.join(additional_tags)}" if additional_tags else ""
+        tags += ",linenums" if linenums else ""
 
-        self.report += f"[source{tags},linenums]\n----\n"
+        self.report += f"[source{tags}]\n----\n"
 
     def _end_source(self):
         self.report += "\n----\n"

--- a/src/actions/report.py
+++ b/src/actions/report.py
@@ -83,11 +83,11 @@ class AbstractReportAction:
     def _end_source(self):
         self.report += "\n----\n"
 
-    def _start_collapsible(self, name):
-        self.report += f"""\n\n.{name}\n[%collapsible]\n====\n"""
+    def _start_collapsible(self, name, sep='===='):
+        self.report += f"""\n\n.{name}\n[%collapsible]\n{sep}\n"""
 
-    def _end_collapsible(self):
-        self.report += """\n====\n\n"""
+    def _end_collapsible(self, sep='===='):
+        self.report += f"""\n{sep}\n\n"""
 
     @staticmethod
     def _get_plan_diff(baseline, changed):

--- a/src/actions/reports/cost.py
+++ b/src/actions/reports/cost.py
@@ -3,17 +3,17 @@ import inspect
 import numpy as np
 import re
 from collections import namedtuple
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from itertools import chain
-from operator import itemgetter
-from typing import Type
+from operator import attrgetter
 
 from matplotlib import pyplot as plt
 from matplotlib import rcParams
 
 from collect import CollectResult
-from objects import Query, PlanNode, ScanNode, PlanNodeVisitor, PlanPrinter
+from objects import PlanNodeVisitor, PlanPrinter, Query
+from objects import AggregateNode, JoinNode, SortNode, PlanNode, ScanNode
 from actions.report import AbstractReportAction
 
 
@@ -28,41 +28,85 @@ REPORT_DESCRIPTION = (
 )
 
 
-PlotSeriesData = namedtuple('PlotSeriesData', ['x', 'cost', 'time_ms', 'node'])
+expr_classifier_pattern = re.compile(
+    '[ (]*((\w+\.)*(?P<column>c\d+)[ )]* *(?P<op>=|>=|<=|<>|<|>)'
+    ' *(?P<rhs>(?P<number>\d+)|(?:ANY \(\'{(?P<lit_array>[0-9,]+)}\'::integer\[\]\))'
+    '|(?:ANY \((?P<bnl_array>ARRAY\[[$0-9a-z_,. ]+\])\))))'
+)
 
 
-@dataclass
+DataPoint = namedtuple('DataPoint', ['x', 'cost', 'time_ms', 'node'])
+
+
+@dataclass(frozen=True)
 class ChartOptions:
     adjust_cost_by_actual_rows: bool = True
     multipy_by_nloops: bool = False
+    log_scale_x: bool = False
+    log_scale_cost: bool = False
+    log_scale_time: bool = False
 
     def __str__(self):
         return ','.join(filter(lambda a: getattr(self, a), self.__dict__.keys()))
 
 
 @dataclass
-class ChartSetSpec:
+class ChartSpec:
     title: str
     description: str
     xlabel: str
     ylabel1: str
     ylabel2: str
     query_filter: Callable[[str],bool]
-    node_filter: Callable[[], bool]
+    node_filter: Callable[[PlanNode], bool]
     x_getter: Callable
-    series_label_suffix: Callable = None
+    series_label_suffix: Callable = lambda node: ''
     options: ChartOptions = field(default_factory=ChartOptions)
 
     file_name: str = ''
     queries: set[str] = field(default_factory=set)
-    series_data: {str: list[PlotSeriesData]} = field(default_factory=dict)
-    series_format: {str: str} = field(default_factory=dict)
-    series_details: {str: list[str]} = field(default_factory=dict)
+    series_data: Mapping[str: Iterable[DataPoint]] = field(default_factory=dict)
+    series_format: Mapping[str: str] = field(default_factory=dict)
+    series_details: Mapping[str: Iterable[str]] = field(default_factory=dict)
+
+    def test_node(self, query_str, node):
+        return self.query_filter(query_str) and self.node_filter(node)
+
+
+class NodeFeatures:
+    def __init__(self, node: PlanNode):
+        self.is_seq_scan = False
+        self.is_any_index_scan = False
+        self.is_aggregate = False
+        self.is_sort = False
+        self.has_index_access_cond = False
+        self.has_scan_filter = False
+        self.has_tfbr_filter = False
+        self.has_local_filter = False
+        self.has_rows_removed_by_recheck = False
+
+        if isinstance(node, ScanNode):
+            self.is_seq_scan = node.is_seq_scan
+            self.is_any_index_scan = node.is_any_index_scan
+            self.has_index_access_cond = bool(node.get_index_cond())
+            self.has_scan_filter = bool(node.get_remote_filter())
+            self.has_tfbr_filter = bool(node.get_remote_tfbr_filter())
+            self.has_local_filter = bool(node.get_local_filter())
+            self.has_rows_removed_by_recheck = bool(node.get_rows_removed_by_recheck())
+        elif isinstance(node, AggregateNode):
+            self.is_aggregate = True
+        elif isinstance(node, SortNode):
+            self.is_sort = True
+
+    def __str__(self):
+        return ','.join(filter(lambda a: getattr(self, a), self.__dict__.keys()))
 
 
 @dataclass
 class PlanFeatures:
     is_single_table: bool = False
+    has_aggregate: bool = False
+    has_sort: bool = False
     has_key_access_index: bool = False
     has_scan_filter_index: bool = False
     has_tfbr_filter_index: bool = False
@@ -76,6 +120,19 @@ class PlanFeatures:
 
     def __str__(self):
         return ','.join(filter(lambda a: getattr(self, a), self.__dict__.keys()))
+
+    def update(self, nf: NodeFeatures):
+        self.has_aggregate |= nf.is_aggregate
+        self.has_sort |= nf.is_sort
+        self.has_table_filter_seqscan |= (nf.is_seq_scan and nf.has_scan_filter)
+        self.has_local_filter |= nf.has_local_filter
+        if nf.is_any_index_scan:
+            self.has_key_access_index |= nf.has_index_access_cond
+            self.has_scan_filter_index |= nf.has_scan_filter
+            self.has_tfbr_filter_index |= nf.has_tfbr_filter
+            self.has_no_filter_index |= not (self.has_scan_filter_index
+                                             or self.has_tfbr_filter_index
+                                             or self.has_local_filter)
 
     def merge(self, other):
         for a in self.__dict__.keys():
@@ -97,6 +154,7 @@ class PlanContext:
 class NodeDetail:
     plan_context: PlanContext
     node_width: int
+    node_features: NodeFeatures
 
     def get_query(self):
         return self.plan_context.get_query()
@@ -106,10 +164,10 @@ class NodeDetail:
 
 
 class PlanNodeCollectorContext:
-    def __init__(self, plan_features):
-        self.seq_scan_nodes: {str: list[ScanNode]} = {}
-        self.any_index_scan_nodes: {str: list[ScanNode]} = {}
-        self.pf = plan_features
+    def __init__(self):
+        self.seq_scan_nodes: Mapping[str: Iterable[ScanNode]] = dict()
+        self.any_index_scan_nodes: Mapping[str: Iterable[ScanNode]] = dict()
+        self.pf = PlanFeatures()
 
     def __str__(self):
         s = ''
@@ -121,6 +179,19 @@ class PlanNodeCollectorContext:
         s += f' plan_features: [{self.pf}]'
         return s
 
+
+class InvalidCostFixer(PlanNodeVisitor):
+    def __init__(self, root: PlanNode):
+        super().__init__()
+        self.root = root
+        self.error = False
+
+    def generic_visit(self, node):
+        if node.fixup_invalid_cost():
+            self.error = True
+        else:
+            super().generic_visit(node)
+        return self.error
 
 class PlanNodeCollector(PlanNodeVisitor):
     def __init__(self, ctx, plan_ctx, node_detail_map, logger):
@@ -144,12 +215,15 @@ class PlanNodeCollector(PlanNodeVisitor):
                                                  or self.ctx.pf.has_table_filter_seqscan
                                                  or self.ctx.pf.has_local_filter)
 
-    def visit_plan_node(self, node):
+    def generic_visit(self, node):
         if self.depth == 0:
             self.__enter()
         self.depth += 1
 
-        self.generic_visit(node)
+        node_feat = NodeFeatures(node)
+        self.ctx.pf.update(node_feat)
+        self.node_detail_map[id(node)] = NodeDetail(self.plan_ctx, None, node_feat)
+        super().generic_visit(node)
 
         self.depth -= 1
         if self.depth == 0:
@@ -174,41 +248,26 @@ class PlanNodeCollector(PlanNodeVisitor):
             if not node_width:
                 node_width = node.plan_width
 
-            self.node_detail_map[id(node)] = NodeDetail(self.plan_ctx, node_width)
+            node_feat = NodeFeatures(node)
+            self.ctx.pf.update(node_feat)
+            self.node_detail_map[id(node)] = NodeDetail(self.plan_ctx, node_width, node_feat)
 
             if node.is_seq_scan:
                 if table not in self.ctx.seq_scan_nodes:
                     self.ctx.seq_scan_nodes[table] = []
                 self.ctx.seq_scan_nodes[table].append(node)
-                self.set_seq_scan_node_features(self.ctx.pf, node)
             elif node.is_any_index_scan:
                 if table not in self.ctx.any_index_scan_nodes:
                     self.ctx.any_index_scan_nodes[table] = []
                 self.ctx.any_index_scan_nodes[table].append(node)
-                self.set_index_scan_node_features(self.ctx.pf, node)
             else:
                 self.logger.warn(f'Unknown ScanNode: node_type={node.node_type}')
 
-        self.generic_visit(node)
+        super().generic_visit(node)
 
         self.depth -= 1
         if self.depth == 0:
             self.__exit()
-
-    @staticmethod
-    def set_seq_scan_node_features(feat, node):
-        feat.has_local_filter = int(node.get_local_filter() is not None)
-        feat.has_table_filter_seqscan |= int(node.get_remote_filter() is not None)
-
-    @staticmethod
-    def set_index_scan_node_features(feat, node):
-        feat.has_local_filter = int(node.get_local_filter()is not None)
-        feat.has_key_access_index |= int(node.get_index_cond()is not None)
-        feat.has_scan_filter_index |= int(node.get_remote_filter()is not None)
-        feat.has_tfbr_filter_index |= int(node.get_remote_tfbr_filter()is not None)
-        feat.has_no_filter_index |= not (feat.has_scan_filter_index
-                                         or feat.has_tfbr_filter_index
-                                         or feat.has_local_filter)
 
     @staticmethod
     def compute_scan_node_width(query):
@@ -223,6 +282,72 @@ class PlanNodeCollector(PlanNodeVisitor):
         return scan_node_width_map
 
 
+class ExpressionAnalyzer:
+    def __init__(self, expr):
+        self.expr = expr
+        self.columns: set[str] = set()
+        self.simple_comp_exprs: int = 0
+        self.literal_in_lists: int = 0
+        self.bnl_in_lists: int = 0
+        self.complex_exprs: int = 0
+        self.prop_list: Iterable[Mapping] = list()
+        self.__analyze()
+
+    def is_simple_expr(self):
+        return (len(self.columns) == 1
+                and self.simple_comp_exprs >= 1
+                and self.literal_in_lists == 0
+                and self.bnl_in_lists == 0
+                and self.complex_exprs == 0)
+
+    def __analyze(self):
+        if not self.expr or not self.expr.strip():
+            return list()
+        for branch in re.split('AND', self.expr):
+            if m := expr_classifier_pattern.match(branch):
+                if column := m.group('column'):
+                    self.columns.add(column)
+                op = m.group('op')
+                rhs = m.group('rhs')
+                number = m.group('number')
+                self.simple_comp_exprs += bool(column and op and number)
+
+                num_list_items = None
+
+                if literal_array := m.group('lit_array'):
+                    num_list_items = len(literal_array.split(','))
+                    self.literal_in_lists += 1
+                    bnl_array = None
+                elif bnl_array := m.group('bnl_array'):
+                    self.bnl_in_lists += 1
+                    num_list_items = self.__count_inlist_items(bnl_array)
+
+                self.prop_list.append(dict(column=column,
+                                           op=op,
+                                           rhs=rhs,
+                                           number=number,
+                                           num_list_items=num_list_items,
+                                           literal_array=literal_array,
+                                           bnl_array=bnl_array,))
+            else:
+                self.complex_exprs += 1
+                self.prop_list.append(dict(complex=branch))
+
+    @staticmethod
+    def __count_inlist_items(expr):
+        start = 0
+        end = 0
+        if ((start := expr.find('= ANY (')) > 0
+            and (end := expr.find(')', start)) > 0):
+            if m := re.search('\$(?P<first>\d+)[ ,\$0-9]+..., \$(?P<last>\d+)',
+                              expr[start:end]):
+                first = int(m.group('first'))
+                last = int(m.group('last'))
+                return last - first + 2
+            return len(expr[start:end].split(','))
+        return 0
+
+
 class CostReport(AbstractReportAction):
     def __init__(self):
         super().__init__()
@@ -232,13 +357,14 @@ class CostReport(AbstractReportAction):
         self.report_location = f'report/{self.start_date}'
         self.image_folder = 'imgs'
 
-        self.table_row_map: { str: float } = {}
-        self.node_detail_map: { int: NodeDetail } = {}
-        self.scan_node_map: { str: { str: [ ScanNode ] } } = {}
-        self.query_map: { str: (Query, PlanFeatures) } = {}
+        self.table_row_map: Mapping[str: float] = dict()
+        self.node_detail_map: Mapping[int: NodeDetail] = dict()
+        self.scan_node_map: Mapping[str: Mapping[ str: Iterable[ScanNode]]] = dict()
+        self.query_map: Mapping[str: tuple[Query, PlanFeatures]] = dict()
 
         self.num_plans: int = 0
         self.num_invalid_cost_plans: int = 0
+        self.num_invalid_cost_plans_fixed: int = 0
         self.num_no_opt_queries: int = 0
 
 
@@ -262,14 +388,16 @@ class CostReport(AbstractReportAction):
             report.report_config(loq.config, "YB")
             report.report_model(loq.model_queries)
 
-        for query in loq.queries:
+        report.logger.info('Processing queries...')
+        for query in sorted(loq.queries, key=lambda query: query.query):
             report.add_query(query)
 
         report.logger.info(f"Processed {len(loq.queries)} queries  {report.num_plans} plans")
         if report.num_no_opt_queries:
             report.logger.warn(f"Queries without non-default plans: {report.num_no_opt_queries}")
         if report.num_invalid_cost_plans:
-            report.logger.warn(f"Plans with invalid costs: {report.num_invalid_cost_plans}")
+            report.logger.warn(f"Plans with invalid costs: {report.num_invalid_cost_plans}"
+                               f", fixed: {report.num_invalid_cost_plans_fixed}")
 
         report.collect_nodes_and_create_plots(chart_specs)
 
@@ -287,37 +415,46 @@ class CostReport(AbstractReportAction):
         for t in tables:
             self.table_row_map[t.name] = t.rows
 
-    def process_plans(self, ctx, parent_query, index):
+    def process_plan(self, ctx, parent_query, index):
         query = parent_query.optimizations[index] if index else parent_query
         plan = query.execution_plan
         if not (ptree := plan.parse_plan()):
-            self.logger.warn(f"=== Failed to parse plan ===\n{plan.full_str}\n===")
+            self.logger.warn(f"=== Failed to parse plan ===\n{plan.full_str}\n")
         else:
             self.num_plans += 1
-            if ptree.has_valid_cost():
-                pctx = PlanContext(parent_query, index, ptree)
-                PlanNodeCollector(ctx, pctx, self.node_detail_map, self.logger).visit(ptree)
-            else:
+            if not ptree.has_valid_cost():
                 self.num_invalid_cost_plans += 1
-                self.logger.warn(f"=== Skipping plan with invalid costs ===\n" \
-                                 f"hints: [{query.explain_hints}]\n" \
-                                 f"{plan.full_str}\n===")
+                invalid_cost_plan = (f'hints: [{query.explain_hints}]\n'
+                                     f'{PlanPrinter.build_plan_tree_str(ptree, actual=False)}')
+                self.logger.debug(f'=== Found plan with invalid costs ===\n{invalid_cost_plan}\n')
+                if InvalidCostFixer(ptree).visit(ptree):
+                    self.logger.warn('*** Failed to fixup invalid costs:\n====\n'
+                                     f'{invalid_cost_plan}\n==== Skipping...')
+                    return
 
-    def add_query(self, query: Type[Query]):
-        self.logger.debug(f'Processing query ({query.query_hash}): {query.query}...')
+                self.num_invalid_cost_plans_fixed += 1
+                self.logger.debug('=== Fixed up invalid costs successfully ===\n'
+                                  f'{PlanPrinter.build_plan_tree_str(ptree, actual=False)}')
+
+        pctx = PlanContext(parent_query, index, ptree)
+        PlanNodeCollector(ctx, pctx, self.node_detail_map, self.logger).visit(ptree)
+
+    def add_query(self, query: type[Query]):
+        self.logger.debug(f'{query.query_hash}: {query.query}...')
         self.add_table_row_count(query.tables)
 
         pf = PlanFeatures()
-        ctx = PlanNodeCollectorContext(pf)
 
-        self.process_plans(ctx, query, index=None)
+        ctx = PlanNodeCollectorContext()
+        self.process_plan(ctx, query, index=None)
+        pf.merge(ctx.pf)
 
         if not query.optimizations:
             self.num_no_opt_queries += 1
         else:
             for ix, opt in enumerate(query.optimizations):
                 if opt.execution_plan and opt.execution_plan.full_str:
-                    self.process_plans(ctx, query, ix)
+                    self.process_plan(ctx, query, ix)
                     pf.merge(ctx.pf)
 
         pf.is_single_table = len(query.tables) == 1
@@ -332,19 +469,19 @@ class CostReport(AbstractReportAction):
                 self.scan_node_map[query.query][table] = []
             self.scan_node_map[query.query][table] += node_list
 
-            for node in node_list:
-                self.logger.debug(
-                    '  '.join(
-                        filter(lambda prop: prop, [
-                            node.name,
-                            node.get_index_cond(with_label=True),
-                            node.get_remote_tfbr_filter(with_label=True),
-                            node.get_remote_filter(with_label=True),
-                            node.get_local_filter(with_label=True),
-                        ])))
+            # for node in node_list:
+            #     self.logger.debug(
+            #         '  '.join(
+            #             filter(lambda prop: prop, [
+            #                 node.name,
+            #                 node.get_index_cond(with_label=True),
+            #                 node.get_remote_tfbr_filter(with_label=True),
+            #                 node.get_remote_filter(with_label=True),
+            #                 node.get_local_filter(with_label=True),
+            #             ])))
         self.query_map[query.query] = (query, pf)
 
-    def report_chart_filters(self, spec: ChartSetSpec):
+    def report_chart_filters(self, spec: ChartSpec):
         self._start_collapsible("Chart specifications")
         self._start_source(["python"])
         self.report += "=== Query Filters ===\n"
@@ -361,7 +498,7 @@ class CostReport(AbstractReportAction):
         self._end_collapsible()
 
     def report_queries(self, queries):
-        self._start_collapsible("Queries")
+        self._start_collapsible(f"Queries ({len(queries)})")
         self._start_source(["sql"])
         self.report += "\n".join([query if query.endswith(";") else f"{query};"
                                   for query in sorted(queries)])
@@ -369,26 +506,50 @@ class CostReport(AbstractReportAction):
         self._end_collapsible()
 
     def report_plot_series_details(self, plot_series_details):
-        self._start_collapsible("Plot series")
-        self._start_source(["text"])
+        combinations = sum([ len(cond) for key, cond in plot_series_details.items() ])
+        self._start_collapsible(
+            f"Search conditions in plot series ({combinations} conditions"
+            f" in {len(plot_series_details.keys())} series)", sep="======")
         for series_label, conditions in sorted(plot_series_details.items()):
-            self.report += f"{series_label}\n"
+            self._start_collapsible(f"`{series_label}` ({len(conditions)})\n")
+            self._start_table('1')
             for cond in sorted(conditions):
-                self.report += f"    {cond}\n"
-        self._end_source()
-        self._end_collapsible()
+                self.report += f"|`pass:[{cond}]`\n"
 
-    def report_plot_series_data(self, plot_series_data, data_labels):
-        self._start_collapsible("Plot data")
-        self._start_source(["text"])
-        if plot_series_data:
-            self.report += f"{data_labels}\n"
-            for series_label, data_points in plot_series_data.items():
-                self.report += f"{series_label}\n"
-                for x, cost, time_ms, _ in data_points:
-                    self.report += f"    ({x}, {cost}, {time_ms})\n"
-        self._end_source()
-        self._end_collapsible()
+            self._end_table()
+            self._end_collapsible()
+
+        self.report += "'''"
+        self._end_collapsible(sep="======")
+
+    def report_plot_data(self, plot_data, data_labels):
+        num_dp = sum([ len(cond) for key, cond in plot_data.items() ])
+        self._start_collapsible(f"Plot data ({num_dp})", sep="=====")
+        self.report += "'''"
+        if plot_data:
+            table_header = '|'.join(data_labels)
+            table_header += f'|node'
+
+            for series_label, data_points in sorted(plot_data.items()):
+                self._start_collapsible(f"`{series_label}` ({len(data_points)})")
+                self._start_table('2,1,1,5')
+                self._start_table_row()
+                self.report += table_header
+                self._end_table_row()
+                for x, cost, time_ms, node in sorted(data_points,
+                                                     key=attrgetter('x','time_ms','cost')):
+                    self.report += f"|{x}\n|{time_ms}\n|{cost}\n|`pass:["
+                    self.report += "  ".join([
+                        node.name,
+                        node.get_search_condition_str(with_label=True),
+                        ('Partial Aggregate' if self.is_scan_with_pushed_down_aggregate(node)
+                         else '')
+                    ])
+                    self.report += "]`\n"
+                self._end_table()
+                self._end_collapsible()
+
+        self._end_collapsible(sep="=====")
 
     def build_report(self, chart_specs):
         self.report += "\n== Description\n"
@@ -398,46 +559,41 @@ class CostReport(AbstractReportAction):
         for i, spec in enumerate(chart_specs):
             self.report += f"=== {i}. {html.escape(spec.title)}\n"
             self.report += f"{spec.description}\n"
-            self._start_table("1")
+            self._start_table()
             self.add_image(spec.file_name, '{title},align=\"center\"')
             self._end_table()
 
-            self._start_table()
-            self._start_table_row()
             self.report_chart_filters(spec)
             self.report_queries(spec.queries)
             self.report_plot_series_details(spec.series_details)
-            self.report_plot_series_data(spec.series_data,
-                                         (f'{html.escape(spec.xlabel)}',
-                                          f'{html.escape(spec.ylabel1)}',
-                                          f'{html.escape(spec.ylabel2)}'))
-            self._end_table_row()
-            self._end_table()
+            self.report_plot_data(spec.series_data,
+                                  (f'{html.escape(spec.xlabel)}', f'time_ms', f'cost'))
 
     __spcrs = " !\"#$%&'()*+,./:;<=>?[\\]^`{|}~"
     __xtab = str.maketrans(" !\"#$%&'()*+,./:;<=>?ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^`{|}~",
                            "---------------------abcdefghijklmnopqrstuvwxyz---------")
-    def make_file_name(self, str_list: list[str]):
+    def make_file_name(self, str_list: Mapping[str]):
         return f"{'-'.join(s.strip(self.__spcrs).translate(self.__xtab) for s in str_list)}.svg"
 
-    def create_node_plots(self, spec):
+    def draw_x_cost_time_plot(self, spec):
         title = spec.title
         xy_labels = [ spec.xlabel, spec.ylabel1, spec.ylabel2 ]
 
         rcParams['font.family'] = 'serif'
-        rcParams['font.size'] = 8
+        rcParams['font.size'] = 10
 
-        fig, axs = plt.subplots(1, 3, figsize=(27, 8),
-                                layout='constrained')
-#                                layout='none' if self.interactive else 'constrained')
+        fig, axs = plt.subplots(1, 3, figsize=(27, 8), layout='constrained')
         fig.suptitle(title, fontsize='xx-large')
 
         chart_ix = [(1, 2), (0, 2), (0, 1)] # cost-time, x-time, x-cost
+        log_scale_axis = [spec.options.log_scale_x,
+                          spec.options.log_scale_cost,
+                          spec.options.log_scale_time]
         for i in range(len(chart_ix)):
             ax = axs[i]
             x, y = chart_ix[i]
-            xlabel = xy_labels[x]
-            ylabel = xy_labels[y]
+            xlabel = xy_labels[x] + (' (log)' if log_scale_axis[x] else '')
+            ylabel = xy_labels[y] + (' (log)' if log_scale_axis[y] else '')
 
             ax.set_box_aspect(1)
             ax.set_title(f'{xlabel} - {ylabel}', fontsize='x-large')
@@ -447,9 +603,9 @@ class CostReport(AbstractReportAction):
                 ax.text(0.5, 0.5, "NO DATA", size=50, family='sans serif', rotation=30.,
                         ha="center", va="center", alpha=0.4)
 
-        for series_label, data_points in spec.series_data.items():
-            transposed_data = np.split(np.array(data_points).transpose(),
-                                       len(PlotSeriesData._fields))
+        for series_label, data_points in sorted(spec.series_data.items()):
+            data_points.sort(key=attrgetter('x','time_ms','cost'))
+            transposed_data = np.split(np.array(data_points).transpose(), len(DataPoint._fields))
             for i in range(len(chart_ix)):
                 x, y = chart_ix[i]
                 ax = axs[i]
@@ -460,8 +616,17 @@ class CostReport(AbstractReportAction):
                         alpha=0.35,
                         picker=self.line_picker)
 
-                ax.set_xbound(lower=0.0)
-                ax.set_ybound(lower=0.0)
+                if log_scale_axis[x]:
+                    ax.set_xscale('log')
+                    ax.set_xbound(lower=1.0)
+                else:
+                    ax.set_xbound(lower=0.0)
+
+                if log_scale_axis[y]:
+                    ax.set_yscale('log')
+                    ax.set_ybound(lower=1.0)
+                else:
+                    ax.set_ybound(lower=0.0)
 
         if self.interactive:
             self.show_charts_and_handle_events(spec, fig, axs)
@@ -473,7 +638,7 @@ class CostReport(AbstractReportAction):
 
             spec.file_name = self.make_file_name([title, xlabel])
             plt.savefig(self.get_image_path(spec.file_name),
-                        dpi=50 if spec.series_data else 600)
+                        dpi=50 if spec.series_data else 300)
 
         plt.close()
 
@@ -490,33 +655,45 @@ class CostReport(AbstractReportAction):
         return float(self.table_row_map.get(node.table_name))
 
     def get_node_width(self, node):
-        return (0 if self.no_project_query(self.get_node_query(node).query)
+        return (0 if self.is_no_project_query(self.get_node_query(node).query)
                 else int(self.node_detail_map[id(node)].node_width))
 
     def get_actual_node_selectivity(self, node):
-        table_rows = self.get_node_table_rows(node)
-        return float(0 if not table_rows or table_rows == 0 else float(node.rows) / table_rows)
+        table_rows = float(self.get_node_table_rows(node))
+        return (float(node.rows) / table_rows) if table_rows else 0
 
-    def collect_nodes_and_create_plots(self, specs: list[ChartSetSpec]):
-        self.logger.debug(f'Collecting plot data points...')
+    @staticmethod
+    def get_series_color(series_label):
+        # choices of colors = [ 'b', 'g', 'r', 'c', 'm', 'k' ]
+        if 'Seq Scan' in series_label:
+            return 'b'
+        elif re.search('Index Scan.*\(PK\)', series_label):
+            return 'm'
+        elif 'Index Scan' in series_label:
+            return 'r'
+        elif 'Index Only Scan' in series_label:
+            return 'g'
+        return 'k'
+
+    def collect_nodes_and_create_plots(self, specs: Mapping[ChartSpec]):
+        self.logger.info(f'Collecting data points...')
 
         for query_str, table_node_list_map in self.scan_node_map.items():
-            for table, node_list in table_node_list_map.items():
+            for node_list in table_node_list_map.values():
                 for node in node_list:
                     for spec in specs:
-                        if not spec.query_filter(query_str) or not spec.node_filter(node):
+                        if not spec.test_node(query_str, node):
                             continue
 
                         spec.queries.add(query_str)
 
-                        series_label = ''
                         if node.is_seq_scan:
-                            series_label += f'Seq Scan'
+                            series_label = f'Seq Scan'
                         elif node.is_any_index_scan:
-                            series_label += ''.join([
+                            series_label = ''.join([
                                 f"{node.node_type}",
-                                ' Backward' if node.is_backward else '',
-                            ])
+                                (' (PK)' if '_pkey' in str(node.index_name) else ''),
+                                (' Backward' if node.is_backward else '')])
                         else:
                             series_label = node.name
 
@@ -537,40 +714,27 @@ class CostReport(AbstractReportAction):
                             spec.series_details[series_label] = set()
 
                         query, _ = self.query_map.get(query_str)
-                        spec.series_data[series_label].append(
-                            PlotSeriesData(xdata, cost, time_ms, node))
+                        spec.series_data[series_label].append(DataPoint(xdata, cost, time_ms, node))
 
                         cond = node.get_search_condition_str(with_label=True)
                         spec.series_details[series_label].add(f"{cond}" if cond
                                                               else "(No Search Condition)")
 
+        self.logger.info(f'Generating plots...')
 
-        colors = [ 'b', 'g', 'r', 'c', 'm', 'y', 'k' ]
-        marker_style = [ 'o', '8', 's', 'p', '*', '+', 'x', 'd',
-                    'v', '^', '<', '>', '1', '2', '3', '4',
-                    'P', 'h', 'H', 'X', 'D', '|', '_']
+        marker_style = [ '.', 'o', 'v', '^', '<',
+                         '>', '8', 's', 'p', '*',
+                         'h', 'H', 'D', 'd', 'P', 'X']
         line_style = [ '-', '--', '-.', ':' ]
 
         for spec in specs:
-            for i, (series_label, node_data) in enumerate(spec.series_data.items()):
-                node_data.sort(key=itemgetter(0,2,1)) # xdata,time,cost
-
-                fmt = colors[ i % len(colors) ]
-                fmt += marker_style[ i % len(marker_style) ]
-
-                if re.search('Seq Scan', series_label):
-                    fmt += ':'
-                elif re.search('Index Scan.*_pkey', series_label):
-                    fmt += '-'
-                elif re.search('Index Scan', series_label):
-                    fmt += '-.'
-                elif re.search('Index Only Scan', series_label):
-                    fmt += '--'
-                else:
-                    fmt += ':'
+            for i, (series_label, data_points) in enumerate(sorted(spec.series_data.items())):
+                fmt = self.get_series_color(series_label)
+                fmt += marker_style[ (i+3) % len(marker_style) ]
+                fmt += line_style[ (i+5) % len(line_style) ]
                 spec.series_format[series_label] = fmt
 
-            self.create_node_plots(spec)
+            self.draw_x_cost_time_plot(spec)
 
     def choose_chart_spec(self, chart_specs):
         choices = '\n'.join([ f'{n}: {s.title}' for n, s in enumerate(chart_specs) ])
@@ -590,22 +754,24 @@ class CostReport(AbstractReportAction):
         if event.xdata is None:
             return False, dict()
         ax = event.inaxes
-        [x], [y] = np.split(ax.transLimits.transform(line.get_xydata()).T, 2)
-        event_x, event_y = ax.transLimits.transform((event.xdata, event.ydata))
-        maxd = 0.02
+        # convert to display pixel coordinate
+        [x], [y] = np.split(ax.transData.transform(line.get_xydata()).T, 2)
+        (event_x, event_y) = (event.x, event.y)
+        maxd = 10 # pixel radius from the pick event point
+
         d = np.sqrt((x - event_x)**2 + (y - event_y)**2)
         # print(f'line={line}\n' \
         #       f'x={x}\ny={y}\n' \
         #       f'event_x={event_x} event_y={event_y}\n' \
         #       f'd={d}\n' \
-        #       f'np.nonzero(d <= maxd)={np.nonzero(d <= maxd)}')
+        #       f'ind where (d <= maxd)={np.nonzero(d <= maxd)}')
         ind, = np.nonzero(d <= maxd)
-
         if len(ind):
             pickx = line.get_xdata()[ind]
             picky = line.get_ydata()[ind]
+            [axxy] = ax.transAxes.inverted().transform([(event.x, event.y)])
             props = dict(line=line, ind=ind, pickx=pickx, picky=picky,
-                         axx=event_x, axy=event_y)
+                         axx=axxy[0], axy=axxy[1])
             return True, props
         else:
             return False, dict()
@@ -614,8 +780,8 @@ class CostReport(AbstractReportAction):
         def on_pick(event):
             ann = anns[id(event.mouseevent.inaxes)]
             series = event.line.get_label()
-            series_data = spec.series_data[series][event.ind[0]]
-            node: PlanNode = series_data.node
+            data_point = spec.series_data[series][event.ind[0]]
+            node: PlanNode = data_point.node
 
             modifiers = event.mouseevent.modifiers
             if 'alt' in modifiers:
@@ -662,101 +828,252 @@ class CostReport(AbstractReportAction):
         fig.canvas.mpl_connect('button_release_event', on_button_release)
         plt.show()
 
-    def no_project_query(self, query_str):
+    def get_plan_features(self, query_str):
+        return self.query_map[query_str][1]
+
+    def is_single_table_query(self, query_str):
+        return self.get_plan_features(query_str).is_single_table
+
+    def is_no_project_query(self, query_str):
         return (query_str.lower().startswith('select 0 from')
                 or query_str.lower().startswith('select count(*) from'))
 
-    def no_filter_indexscan_query(self, query_str):
-        _, pf = self.query_map.get(query_str)
-        return pf.has_no_filter_index if pf else False
+    def has_no_filter_indexscan(self, query_str):
+        return self.get_plan_features(query_str).has_no_filter_index
 
-    def scan_filter_indexscan_query(self, query_str):
-        _, pf = self.query_map.get(query_str)
-        return pf.has_scan_filter_index if pf else False
+    def has_scan_filter_indexscan(self, query_str):
+        return self.get_plan_features(query_str).has_scan_filter_index
 
-    def tfbr_filter_indexscan_query(self, query_str):
-        _, pf = self.query_map.get(query_str)
-        return pf.has_tfbr_filter_index if pf else False
+    def has_tfbr_filter_indexscan(self, query_str):
+        return self.get_plan_features(query_str).has_tfbr_filter_index
 
-    def local_filter_query(self, query_str):
-        _, pf = self.query_map.get(query_str)
-        return pf.has_local_filter if pf else False
+    def has_local_filter(self, query_str):
+        return self.get_plan_features(query_str).has_local_filter
+
+    def has_aggregate(self, query_str):
+        return self.get_plan_features(query_str).has_aggregate
+
+    @staticmethod
+    def is_scan_with_pushed_down_aggregate(node):
+        return isinstance(node, ScanNode) and bool(node.get_property('Partial Aggregate'))
 
     @staticmethod
     def is_simple_literal_condition(expr):
-        if not expr or len(expr) == 0:
-            return True
-        for branch in re.split(r'AND', expr):
-            if re.search(r'[ (]*((\w+\.)*c\d+[ )]* *(?:=|>=|<=|<>|<|>) *\d+)', branch):
-                pass
-            else:
-                return False
-        return True
+        # TODO: cache analyzed results
+        return not expr or ExpressionAnalyzer(expr).is_simple_expr()
 
     @staticmethod
-    def count_inlist_items(expr):
-        if ((start := expr.find('= ANY (')) > 0
-            and (end := expr.find(')', start)) > 0):
-            if m := re.search('\$(?P<first>\d+)[ ,\$0-9]+..., \$(?P<last>\d+)', expr[start:end]):
-                first = int(m.group('first'))
-                last = int(m.group('last'))
-                return last - first + 2, True
-            return len(expr[start:end].split(',')), False
-        return 0, False
+    def count_literal_inlist_items(expr):
+        num_item_str_list = list()
+        # TODO: cache analyzed results
+        for ea_prop in ExpressionAnalyzer(expr).prop_list:
+            if ea_prop.get('literal_array'):
+                num_item_str_list.append(str(ea_prop.get('num_list_items')))
+
+        return ('x'.join(filter(lambda item: bool(item), sorted(num_item_str_list)))
+                if num_item_str_list else '')
 
     def has_simple_index_cond(self, node, index_cond_only=False):
-        return ((index_cond := str(node.get_index_cond()))
+        index_cond = node.get_index_cond()
+        return (index_cond
                 and self.is_simple_literal_condition(index_cond)
-                and (index_cond_only == False
+                and (not index_cond_only
                      or node.has_no_filter()))
 
-    def has_inlist_index_cond(self, node, parameterized=None):
-        return ((index_cond := str(node.get_index_cond()))
+    def has_inlist_index_cond(self, node, parameterized=False):
+        index_cond = str(node.get_index_cond())
+        return (index_cond
                 and (eq_any_start := index_cond.find('= ANY (')) > 0
                 and (eq_any_end := index_cond.find(')', eq_any_start)) > 0
-                and (parameterized is None
+                and (not parameterized
                      or parameterized == (index_cond.find('$', eq_any_start, eq_any_end) > 0)))
 
     def get_chart_specs(self):
         return [
-            ChartSetSpec(
-                'No filter index scans and seq scans, simple condition on single key',
-                ("Index (Only) Scans with simple index access condition on single key item"
-                 " and the Seq Scans from the same queries. No IN-list, OR'ed condition, etc."),
-                'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
-                lambda query: self.no_filter_indexscan_query(query),
-                lambda node: (self.has_simple_index_cond(node, index_cond_only=True)
-                              or (node.is_seq_scan and node.get_remote_filter())),
-                self.get_actual_node_selectivity,
+            ChartSpec(
+                ('Simple index access conditions and corresponding seq scans by node type'
+                 ' (t100000 and t100000w)'),
+                ('Index (Only) Scans with simple index access condition on single key item'
+                 ' and the Seq Scans from the same queries.'
+                 '\n\n* No IN-list, OR\'ed condition, etc.'
+                 '\n\n* The nodes showing "Rows Removed by (Index) Recheck" are excluded.'
+                 '\n\n* No nodes from EXISTS and JOIN queries'),
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: (('t100000 ' in query or 't100000w ' in query)
+                               and 'exist' not in query
+                               and 'join' not in query
+                               and self.has_no_filter_indexscan(query)
+                               and not self.has_local_filter(query)
+                               and not self.has_aggregate(query)),
+                lambda node: (float(self.get_node_table_rows(node)) == 100000
+                              and node.get_rows_removed_by_recheck() == 0
+                              and (self.has_simple_index_cond(node, index_cond_only=True)
+                                   or (node.is_seq_scan and node.get_remote_filter()))),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node:
+                                     f' {node.table_name}:width={self.get_node_width(node)}'),
+            ),
+            ChartSpec(
+                ('Simple index scans and seq scans, series by index'
+                 ' (t100000)'),
+                ('Index (Only) Scans with simple index access condition on single key item'
+                 ' and the Seq Scans from the same queries.'
+                 '\n\n* No IN-list, OR\'ed condition, etc.'
+                 '\n\n* The nodes showing "Rows Removed by (Index) Recheck" are excluded.'
+                 '\n\n* No nodes from EXISTS and JOIN queries'),
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: ('t100000 ' in query
+                               and 'exist' not in query
+                               and 'join' not in query
+                               and self.has_no_filter_indexscan(query)
+                               and not self.has_local_filter(query)
+                               and not self.has_aggregate(query)),
+                lambda node: (float(self.get_node_table_rows(node)) == 100000
+                              and node.get_rows_removed_by_recheck() == 0
+                              and (self.has_simple_index_cond(node, index_cond_only=True)
+                                   or (node.is_seq_scan and node.get_remote_filter()))),
+                x_getter=lambda node: float(node.rows),
                 series_label_suffix=(lambda node:
                                      f' {node.index_name or node.table_name}:'
                                      f'width={self.get_node_width(node)}'),
             ),
-            ChartSetSpec(
+            ChartSpec(
+                ('Simple index scans and seq scans, series by index'
+                 ' (t100000w)'),
+                ('Index (Only) Scans with simple index access condition on single key item'
+                 ' and the Seq Scans from the same queries.'
+                 '\n\n* No IN-list, OR\'ed condition, etc.'
+                 '\n\n* The nodes showing "Rows Removed by (Index) Recheck" are excluded.'
+                 '\n\n* No nodes from EXISTS and JOIN queries'),
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: ('t100000w ' in query
+                               and 'exist' not in query
+                               and 'join' not in query
+                               and self.has_no_filter_indexscan(query)
+                               and not self.has_local_filter(query)
+                               and not self.has_aggregate(query)),
+                lambda node: (float(self.get_node_table_rows(node)) == 100000
+                              and node.get_rows_removed_by_recheck() == 0
+                              and (self.has_simple_index_cond(node, index_cond_only=True)
+                                   or (node.is_seq_scan and node.get_remote_filter()))),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node:
+                                     f' {node.index_name or node.table_name}:'
+                                     f'width={self.get_node_width(node)}'),
+            ),
+            ChartSpec(
+                ('Simple index scans and seq scans, series by index'
+                 ' (t10000)'),
+                ('Index (Only) Scans with simple index access condition on single key item'
+                 ' and the Seq Scans from the same queries.'
+                 '\n\n* No IN-list, OR\'ed condition, etc.'
+                 '\n\n* The nodes showing "Rows Removed by (Index) Recheck" are excluded.'
+                 '\n\n* No nodes from EXISTS and JOIN queries'),
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: ('t10000 ' in query
+                               and 'exist' not in query
+                               and 'join' not in query
+                               and self.has_no_filter_indexscan(query)
+                               and not self.has_local_filter(query)
+                               and not self.has_aggregate(query)),
+                lambda node: (float(self.get_node_table_rows(node)) == 10000
+                              and node.get_rows_removed_by_recheck() == 0
+                              and (self.has_simple_index_cond(node, index_cond_only=True)
+                                   or (node.is_seq_scan and node.get_remote_filter()))),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node:
+                                     f' {node.index_name or node.table_name}:'
+                                     f'width={self.get_node_width(node)}'),
+            ),
+            ChartSpec(
+                ('Simple index scans and seq scans, series by index'
+                 ' (t1000)'),
+                ('Index (Only) Scans with simple index access condition on single key item'
+                 ' and the Seq Scans from the same queries.'
+                 '\n\n* No IN-list, OR\'ed condition, etc.'
+                 '\n\n* The nodes showing "Rows Removed by (Index) Recheck" are excluded.'
+                 '\n\n* No nodes from EXISTS and JOIN queries'),
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: ('t1000 ' in query
+                               and 'exist' not in query
+                               and 'join' not in query
+                               and self.has_no_filter_indexscan(query)
+                               and not self.has_local_filter(query)
+                               and not self.has_aggregate(query)),
+                lambda node: (float(self.get_node_table_rows(node)) == 1000
+                              and node.get_rows_removed_by_recheck() == 0
+                              and (self.has_simple_index_cond(node, index_cond_only=True)
+                                   or (node.is_seq_scan and node.get_remote_filter()))),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node:
+                                     f' {node.index_name or node.table_name}:'
+                                     f'width={self.get_node_width(node)}'),
+            ),
+            ChartSpec(
+                ('Simple index scans and seq scans, series by index'
+                 ' (t100)'),
+                ('Index (Only) Scans with simple index access condition on single key item'
+                 ' and the Seq Scans from the same queries.'
+                 '\n\n* No IN-list, OR\'ed condition, etc.'
+                 '\n\n* The nodes showing "Rows Removed by (Index) Recheck" are excluded.'
+                 '\n\n* No nodes from EXISTS and JOIN queries'),
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: ('t100 ' in query
+                               and 'exist' not in query
+                               and 'join' not in query
+                               and self.has_no_filter_indexscan(query)
+                               and not self.has_local_filter(query)
+                               and not self.has_aggregate(query)),
+                lambda node: (float(self.get_node_table_rows(node)) == 100
+                              and node.get_rows_removed_by_recheck() == 0
+                              and (self.has_simple_index_cond(node, index_cond_only=True)
+                                   or (node.is_seq_scan and node.get_remote_filter()))),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node:
+                                     f' {node.index_name or node.table_name}:'
+                                     f'width={self.get_node_width(node)}'),
+            ),
+            ChartSpec(
                 'Index scan nodes with literal IN-list',
-                ("Index (Only) Scans with literal IN-list in the index access condition."
-                 "\n\n  * The series are grouped by node_width and the number of IN-list items"),
-                'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
-                lambda query: True,
+                ("Index (Only) Scans with literal IN-list in the index access condition."),
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: ' in (' in query.lower(),
                 lambda node: (self.has_inlist_index_cond(node, parameterized=False)
+                              and node.get_rows_removed_by_recheck() == 0
                               and node.has_no_filter()),
-                self.get_actual_node_selectivity,
+                x_getter=lambda node: float(node.rows),
                 series_label_suffix=(lambda node:
                                      f'{ node.index_name}:width={self.get_node_width(node)}'),
             ),
-            ChartSetSpec(
+            ChartSpec(
+                'Index scan nodes with literal IN-list (output <= 200 rows)',
+                ("Index (Only) Scans with literal IN-list in the index access condition."
+                 "\n\n  * The series are grouped by node_width and the number of IN-list items"),
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: ' in (' in query.lower(),
+                lambda node: (self.has_inlist_index_cond(node, parameterized=False)
+                              and node.get_rows_removed_by_recheck() == 0
+                              and node.has_no_filter()
+                              and float(node.rows) <= 200),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node: f'{ node.index_name}'
+                                     f':width={self.get_node_width(node)}'
+                                     f' IN={self.count_literal_inlist_items(node.get_index_cond())}'),
+            ),
+            ChartSpec(
                 'Parameterized IN-list index scans (BNL)',
                 ("Index (Only) Scans with BNL-generaed parameterized IN-list, plus the Seq Scans"
                  " from the same queries."),
-                'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
                 lambda query: True,
                 lambda node: (self.has_inlist_index_cond(node, parameterized=True)
+                              and node.get_rows_removed_by_recheck() == 0
                               and node.has_no_filter()),
-                x_getter=self.get_actual_node_selectivity,
+                x_getter=lambda node: float(node.rows),
                 series_label_suffix=(lambda node: f'{ node.index_name}:width="'
                                      f'{self.get_node_width(node)} loops={node.nloops}'),
             ),
-            ChartSetSpec(
+            ChartSpec(
                 'Composite key index scans',
                 ("* The clustered plots near the lower left corner need adjustments the series"
                  " criteria and/or node filtering."
@@ -764,53 +1081,146 @@ class CostReport(AbstractReportAction):
                  " the series criteria.\n\ne.g.: for index key `(c3, c4, c5)`,"
                  " condition: `c4 >= x and c5 = y` then the prefix NDV would be:"
                  " `select count(*) from (select distinct c3, c4 from t where c4 >= x) v;`"),
-                'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
-                lambda query: 't1000000m' in query,
-                lambda node: (not node.get_local_filter()
-                              and ((node.is_seq_scan
-                                    and (not (expr := node.get_remote_filter())
-                                         or self.is_simple_literal_condition(expr)))
-                                   or self.has_simple_index_cond(node, index_cond_only=True))),
-                x_getter=self.get_actual_node_selectivity,
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: 't1000000m' in query or 't100000c10' in query,
+                lambda node: (self.has_simple_index_cond(node, index_cond_only=True)
+                              and node.get_rows_removed_by_recheck() == 0),
+                x_getter=lambda node: float(node.rows),
                 series_label_suffix=(lambda node: f'{ node.index_name} loops={node.nloops}'),
             ),
-            ChartSetSpec(
-                'Scans with remote index and/or table filter',
+            ChartSpec(
+                'Composite key index scans (exclude too high costs >= 100000000)',
+                ("* The clustered plots near the lower left corner need adjustments the series"
+                 " criteria and/or node filtering."
+                 "\n\n  * Try adding index key prefix NDV before the first equality to"
+                 " the series criteria.\n\ne.g.: for index key `(c3, c4, c5)`,"
+                 " condition: `c4 >= x and c5 = y` then the prefix NDV would be:"
+                 " `select count(*) from (select distinct c3, c4 from t where c4 >= x) v;`"),
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: 't1000000m' in query or 't100000c10' in query,
+                lambda node: (self.has_simple_index_cond(node, index_cond_only=True)
+                              and node.get_rows_removed_by_recheck() == 0
+                              and float(node.total_cost) < 100000000),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node: f'{ node.index_name} loops={node.nloops}'),
+            ),
+            ChartSpec(
+                'Composite key index scans (output <= 100 rows)',
+                ("* The clustered plots near the lower left corner need adjustments the series"
+                 " criteria and/or node filtering."
+                 "\n\n  * Try adding index key prefix NDV before the first equality to"
+                 " the series criteria.\n\ne.g.: for index key `(c3, c4, c5)`,"
+                 " condition: `c4 >= x and c5 = y` then the prefix NDV would be:"
+                 " `select count(*) from (select distinct c3, c4 from t where c4 >= x) v;`"),
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: 't1000000m' in query or 't100000c10' in query,
+                lambda node: (self.has_simple_index_cond(node, index_cond_only=True)
+                              and node.get_rows_removed_by_recheck() == 0
+                              and float(node.rows) <= 100),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node: f'{ node.index_name} loops={node.nloops}'),
+            ),
+            ChartSpec(
+                'Scans with simple remote index and/or table filter',
                 "* Index (Only) Scans may or may not have index access condition as well.",
-                'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
-                lambda query: self.scan_filter_indexscan_query(query),
-                lambda node: (node.get_remote_filter()
-                              or node.get_remote_tfbr_filter()),
-                x_getter=self.get_actual_node_selectivity,
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: self.has_scan_filter_indexscan(query),
+                lambda node: (not node.has_no_filter()
+                              and not node.get_local_filter()
+                              and self.is_simple_literal_condition(node.get_search_condition_str())),
+                x_getter=lambda node: float(node.rows),
                 series_label_suffix=(lambda node: f' {node.index_name or node.table_name}:width={self.get_node_width(node)} loops={node.nloops}'),
             ),
-            ChartSetSpec(
+            ChartSpec(
                 'Scans with simple filter(s)',
-                "This is to get some data points comparable to 'Scans with remote index and/or table filter' chartset on PG",
-                'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
+                'For PG comparisons',
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
                 lambda query: True,
                 lambda node: (not node.has_no_filter()
                               and self.is_simple_literal_condition(node.get_search_condition_str())
                               and 'ANY' not in node.get_search_condition_str()),
-                x_getter=self.get_actual_node_selectivity,
+                x_getter=lambda node: float(node.rows),
                 series_label_suffix=(lambda node: f' {node.index_name or node.table_name}:width={self.get_node_width(node)} loops={node.nloops}'),
             ),
-            ChartSetSpec(
-                '(WIP) Scans with local filter, may have index access condition and/or remote filter',
+            ChartSpec(
+                'Scans with complex (but no IN-lists) remote index and/or table filter',
+                "* Index (Only) Scans may or may not have index access condition as well.",
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: self.has_scan_filter_indexscan(query),
+                lambda node: (not node.has_no_filter()
+                              and not node.get_local_filter()
+                              and not self.is_simple_literal_condition(
+                                  node.get_search_condition_str())
+                              and 'ANY' not in node.get_search_condition_str()),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node: f' {node.index_name or node.table_name}:width={self.get_node_width(node)} loops={node.nloops}'),
+            ),
+            ChartSpec(
+                'Scans with complex (but no IN-lists) index and/or table filter',
+                'For PG comparisons',
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: True,
+                lambda node: (not node.has_no_filter()
+                              and not self.is_simple_literal_condition(
+                                  node.get_search_condition_str())
+                              and 'ANY' not in node.get_search_condition_str()),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node: f' {node.index_name or node.table_name}:width={self.get_node_width(node)} loops={node.nloops}'),
+            ),
+            ChartSpec(
+                'Full scan + agg push down by table rows (linear scale)',
+                ('Scan nodes from `select count(*) from ...` single table queries without'
+                 ' any search conditions'
+                 '\n\n* The costs are not adjusted'),
+                'Table rows', 'Estimated cost', 'Execution time [ms]',
+                lambda query: self.has_aggregate(query),
+                lambda node: (self.is_scan_with_pushed_down_aggregate(node)
+                              and not node.get_local_filter()),
+                x_getter=lambda node: float(self.get_node_table_rows(node)),
+                series_label_suffix=(lambda node: f' {node.index_name or node.table_name}'),
+                options=ChartOptions(adjust_cost_by_actual_rows=False),
+            ),
+            ChartSpec(
+                'Full scan + agg push down by table rows (log scale)',
+                ('Scan nodes from `select count(*) from ...` single table queries without'
+                 ' any search conditions'
+                 '\n\n* The costs are not adjusted'),
+                'Table rows', 'Estimated cost', 'Execution time [ms]',
+                lambda query: (self.has_aggregate(query)
+                               and not self.has_local_filter(query)),
+                lambda node: self.is_scan_with_pushed_down_aggregate(node),
+                x_getter=lambda node: float(self.get_node_table_rows(node)),
+                series_label_suffix=(lambda node: f' {node.index_name or node.table_name}'),
+                options=ChartOptions(adjust_cost_by_actual_rows=False,
+                                     log_scale_x=True,
+                                     log_scale_cost=True,
+                                     log_scale_time=True),
+            ),
+            ChartSpec(
+                '(EXP) Scans with local filter, may have index access condition and/or remote filter',
                 '* need to add the queries and figure out series grouping and query/node selection',
-                'In/out row count ratio', 'Estimated cost', 'Execution time [ms]',
-                lambda query: self.scan_filter_indexscan_query(query),
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: self.has_scan_filter_indexscan(query),
                 lambda node: node.get_local_filter(),
-                x_getter=self.get_actual_node_selectivity,
+                x_getter=lambda node: float(node.rows),
                 series_label_suffix=(lambda node: f' {node.index_name or node.table_name}:width={self.get_node_width(node)} loops={node.nloops}'),
             ),
-            ChartSetSpec(
-                '(WIP) No filter full scans by output rows',
+            ChartSpec(
+                '(EXP) No filter full scans',
                 '* need to adjust series grouping and query/node selection',
                 'Output rows', 'Estimated cost', 'Execution time [ms]',
-                lambda query: True,
+                lambda query: 'select count(*) from' not in query,
                 lambda node: (node.has_no_filter() and not node.get_index_cond()),
                 x_getter=lambda node: float(node.rows),
                 series_label_suffix=(lambda node: f' {node.index_name or node.table_name} width={self.get_node_width(node)}'),
+            ),
+            ChartSpec(
+                '(EXP) All the scan nodes',
+                ('For examining all the collected nodes'),
+                'Output row count', 'Estimated cost', 'Execution time [ms]',
+                lambda query: True,
+                lambda node: isinstance(node, ScanNode),
+                x_getter=lambda node: float(node.rows),
+                series_label_suffix=(lambda node: f' width={self.get_node_width(node)}'),
             ),
         ]

--- a/src/db/abstract.py
+++ b/src/db/abstract.py
@@ -7,6 +7,11 @@ class PlanNodeAccessor(ABC):
     def has_valid_cost(node):
         pass
 
+    @staticmethod
+    @abstractmethod
+    def fixup_invalid_cost(node):
+        pass
+
     # ScanNode methods
 
     @staticmethod

--- a/src/db/abstract.py
+++ b/src/db/abstract.py
@@ -59,3 +59,8 @@ class PlanNodeAccessor(ABC):
     @abstractmethod
     def get_rows_removed_by_recheck(node, with_label=False):
         pass
+
+    @staticmethod
+    @abstractmethod
+    def is_scan_with_partial_aggregate(node):
+        pass

--- a/src/models/sql.py
+++ b/src/models/sql.py
@@ -175,7 +175,7 @@ class SQLModel(QTFModel):
                 created_tables.append(table)
 
             table.fields.append(Field(name=cname, position=cpos,
-                                      is_index=(inames != None),
+                                      is_index=bool(inames),
                                       indexes=inames,
                                       defined_width=clen))
 

--- a/src/objects.py
+++ b/src/objects.py
@@ -2,6 +2,7 @@ import dataclasses
 from enum import Enum
 import re
 
+from collections.abc import Iterable, Mapping
 from typing import List, Dict, Type
 
 from config import Config
@@ -131,7 +132,7 @@ class Optimization(Query):
 
 class PlanNode:
     def __init__(self, accessor: PlanNodeAccessor, node_type):
-        self.acc = accessor
+        self.acc: PlanNodeAccessor = accessor
         self.node_type: str = node_type
         self.level: int = 0
         self.name: str = None


### PR DESCRIPTION
Cost report charts:

* Simple index scan chart for each table size

* Small output composite key and IN-list charts

* Take into account number of items in multiple IN-lists

Fixes:

* Fix misbehavior because of ambiguity in data type and None vs. 0/empty values.

  e.g.:
  - PostgresPlanNodeAccessor.get_rows_removed_by_recheck return value
  - Field.is_index ctor argument

* Fix an issue where the last property of the last node was missing when the plan text lacks the last newline.
  (e.g. "...\n      Partial Aggregate: true")

* Fix a tree traversal problem when overriding non-node-type-specific method. In the PlanNodeVisitor subclasses, override `generic_visit` instead of `visit`, and call super().generic_visit instead of self.generic_visit.

Enhancements:

* Add PlanNode subclasses: AggregateNode, JoinNode and SortNode

* Add sep(arator) argument to AbstractReportAction._start_collapsible and _end_collapsible to allow nested collapsible.

* Fixup the cost values that appear to be including the PG disable_cost (best effort)

* Color coding by node type

* Log scaling ChartOptions

* Chart detail section improvements:

  - Show each data series detail in a table under collapsible block.

  - Show node name, search conditions and partial aggregate (if it has one) for each data point.

* ExpressionAnalyzer for more detail search condition expression classification and counting items in multiple IN-lists.

Clean up:

* Stop using obsolete typing collection types and use recommended abstract types in the type hints and annotations. (around the code being modified in this commit only)

  e.g. Iterable instead of List, etc. https://docs.python.org/3/library/typing.html?#deprecated-aliases