### PR TITLE
add query plan subreports to cost report

### DIFF
--- a/src/actions/reports/cost_chart_specs.py
+++ b/src/actions/reports/cost_chart_specs.py
@@ -20,7 +20,7 @@ class PlotType(Enum):
 
 @dataclass(frozen=True)
 class ChartOptions:
-    adjust_cost_by_actual_rows: bool = True
+    adjust_cost_by_actual_rows: bool = False
     multipy_by_nloops: bool = False
     log_scale_x: bool = False
     log_scale_cost: bool = False
@@ -136,6 +136,11 @@ class CostChartSpecs:
                 '',
                 self.literal_in_list_specs,
             ),
+            ChartGroup(
+                "Index scan nodes with parameterized IN-list created by BNL",
+                '',
+                self.bnl_in_list_specs,
+            ),
         ]
 
         self.exp_chart_groups = [
@@ -187,6 +192,7 @@ class CostChartSpecs:
                     and not cm.has_partial_aggregate(node)
                 ),
                 x_getter=lambda node: 1,
+                options=ChartOptions(adjust_cost_by_actual_rows=True),
             )).make_variant(
                 'Per row cost/time ratio of the scan nodes (width=0, rows>=1)', True,
                 ('  ((total_cost - startup_cost) / estimated_rows)'
@@ -236,6 +242,7 @@ class CostChartSpecs:
                 and not cm.has_partial_aggregate(node)
             ),
             x_getter=lambda node: 0,
+            options=ChartOptions(adjust_cost_by_actual_rows=False),
         )
 
         column_and_value_metric_single_column_chart = (
@@ -338,6 +345,7 @@ class CostChartSpecs:
                 series_suffix=(lambda node:
                                f'{node.index_name or node.table_name}:'
                                f'width={cm.get_node_width(node)}'),
+                options=ChartOptions(adjust_cost_by_actual_rows=True),
             )).make_variant(
                 'Table t100000 and t100000w, series by node type', True,
                 xtra_query_filter=lambda query: 't100000 ' in query or 't100000w ' in query,
@@ -450,6 +458,7 @@ class CostChartSpecs:
                                f'{node.index_name}:width={cm.get_node_width(node)}'
                                f' loops={node.nloops}'
                                ),
+                options=ChartOptions(adjust_cost_by_actual_rows=True),
             ),
         ]
 

--- a/src/actions/reports/cost_metrics.py
+++ b/src/actions/reports/cost_metrics.py
@@ -128,6 +128,9 @@ class NodeContext:
     node_width: int
     node_classifiers: NodeClassifiers
 
+    def get_parent_query(self):
+        return self.plan_context.parent_query
+
     def get_query(self):
         return self.plan_context.get_query()
 
@@ -384,7 +387,7 @@ class CostMetrics:
         PlanNodeCollector(ctx, pctx, self.node_context_map, self.logger).visit(ptree)
 
     def add_query(self, query: type[Query]):
-        self.logger.debug(f'{query.query_hash}: {query.query}...')
+        self.logger.debug(f'Adding {query.tag} {query.query_hash}: {query.query}...')
         self.add_table_metadata(query.tables)
 
         pc = PlanClassifiers()
@@ -414,6 +417,9 @@ class CostMetrics:
 
     def get_node_query(self, node):
         return self.node_context_map[id(node)].get_query()
+
+    def get_node_parent_query(self, node):
+        return self.node_context_map[id(node)].get_parent_query()
 
     def get_node_query_str(self, node):
         return self.get_node_query(node).query

--- a/src/objects.py
+++ b/src/objects.py
@@ -154,11 +154,11 @@ class Optimization(Query):
 
 
 class PlanNode:
-    def __init__(self, accessor: PlanNodeAccessor, node_type):
+    def __init__(self, accessor: PlanNodeAccessor, node_type, node_name):
         self.acc: PlanNodeAccessor = accessor
         self.node_type: str = node_type
         self.level: int = 0
-        self.name: str = None
+        self.name: str = node_name
         self.properties: Mapping[str: str] = dict()
         self.child_nodes: Iterable[PlanNode] = list()
 
@@ -176,14 +176,14 @@ class PlanNode:
         pass  # todo
 
     def __str__(self):
-        return self.name
+        return self.get_full_str(estimate=True, actual=True)
 
     def get_full_str(self, estimate=True, actual=True, properties=False, level=False):
         return ''.join([
             f'{self.level}: ' if level else '',
             self.name,
             f'  {self.get_estimate_str()}' if estimate else '',
-            f'  {self.get_actual_str()}' if actual else '',
+            f' {self.get_actual_str()}' if actual else '',
             str(self.properties) if properties and len(self.properties) > 0 else '',
         ])
 
@@ -213,9 +213,9 @@ class PlanNode:
 
 
 class ScanNode(PlanNode):
-    def __init__(self, accessor, node_type, table_name, table_alias, index_name,
+    def __init__(self, accessor, node_type, node_name, table_name, table_alias, index_name,
                  is_backward, is_distinct, is_parallel):
-        super().__init__(accessor, node_type)
+        super().__init__(accessor, node_type, node_name)
         self.table_name: str = table_name
         self.table_alias: str = table_alias
         self.index_name: str = index_name
@@ -230,7 +230,7 @@ class ScanNode(PlanNode):
 
     def __str__(self):
         return '  '.join(filter(lambda s: s,
-                                [self.name,
+                                [self.get_full_str(),
                                  self.get_search_condition_str(with_label=True),
                                  ('Partial Aggregate'
                                   if self.is_scan_with_partial_aggregate() else '')]))


### PR DESCRIPTION
* Add test query list grouped by .sql file and each file name linked to a subreport showing all the plans.

* Add query hash to each data point report item with the link to the query plan with the corresponding node highlighted. (highlighted not working with disable_cost at the moment.)

* Combine outliers and normal data point reporting function.