### PR TITLE
Improve bucketized queries

### DIFF
--- a/sql/cost-validation-bucketized/queries/bucketized-bitmap.sql
+++ b/sql/cost-validation-bucketized/queries/bucketized-bitmap.sql
@@ -92,3 +92,45 @@ WHERE EXISTS (
     WHERE t.c2 = t2.c2
 )
 ORDER BY c1,c2;
+
+
+SELECT c2, c3
+FROM t1000
+WHERE c2 > c3 AND c3 < c4
+    OR c2 = ANY (
+        ARRAY[
+            100,
+            101,
+            102,
+            103,
+            104,
+            105,
+            106,
+            107,
+            108,
+            109
+        ]
+    )
+    AND c2 >= 100
+ORDER BY c2, c3;
+
+
+SELECT c4, c5
+FROM table_bucketized
+WHERE c4 > c5 AND c6 IS NOT NULL
+    OR c4 = ANY (
+        ARRAY[
+            10000,
+            10001,
+            10002,
+            10003,
+            10004,
+            10005,
+            10006,
+            10007,
+            10008,
+            10009
+        ]
+    )
+    AND c4 >= 10000
+ORDER BY c4, c5;

--- a/sql/cost-validation-bucketized/queries/bucketized-complex-fn.sql
+++ b/sql/cost-validation-bucketized/queries/bucketized-complex-fn.sql
@@ -380,3 +380,67 @@ select c1, c2, c5,
 from t1000000m
 where bucketid in (0,1,2)
 order by c1, c2;
+
+
+WITH seed AS (
+    SELECT c1
+    FROM t100
+    WHERE bucketid IN (0,1,2)
+)
+SELECT seed.c1, t.c2, t.c3
+FROM seed,
+LATERAL (
+    SELECT a.c2, b.c3
+    FROM t10000 a
+    FULL JOIN t10000 b
+      ON a.c1 = b.c1
+    WHERE a.c1 = seed.c1
+      AND nullif(a.c2, 0) IS NOT NULL
+      AND coalesce(a.c3, 0) + coalesce(b.c3, 0) < 150
+      AND abs(coalesce(a.c4, 0) - coalesce(b.c4, 0)) BETWEEN 1 AND 500
+      AND mod(coalesce(a.c2, 0) + coalesce(b.c2, 0), 11) IN (2,4,8)
+) t
+ORDER BY t.c2, t.c3;
+
+
+WITH seed AS (
+    SELECT c1
+    FROM t100
+    WHERE bucketid IN (0,1,2)
+)
+SELECT seed.c1, t.c2, t.c4
+FROM seed,
+LATERAL (
+    SELECT a.c2, b.c4
+    FROM t10000 a
+    FULL JOIN t10000 b
+      ON a.c1 = b.c1
+    WHERE a.c1 = seed.c1
+      AND coalesce(a.c2, 0) > 10
+      AND sign(coalesce(a.c3, 0) - coalesce(b.c3, 0)) >= 0
+      AND power(coalesce(a.c4, 0) - coalesce(b.c4, 0), 2) < 10000
+      AND mod(abs(coalesce(a.c2, 0) - coalesce(b.c2, 0)), 13) IN (1,5,9)
+) t
+ORDER BY t.c2, t.c4;
+
+
+WITH seed AS (
+    SELECT c1
+    FROM t100
+    WHERE bucketid IN (0,1,2)
+)
+SELECT seed.c1, t.c2, t.c3
+FROM seed,
+LATERAL (
+    SELECT a.c2, b.c3
+    FROM t10000 a
+    FULL JOIN t10000 b
+      ON a.c1 = b.c1
+    WHERE a.c1 = seed.c1
+      AND coalesce(a.c2, 0) > 10
+      AND width_bucket(coalesce(a.c3, 0), 0, 2000, 10) <= 5
+      AND width_bucket(coalesce(b.c4, 0), 0, 2000, 10) BETWEEN 1 AND 7
+      AND mod(abs(coalesce(a.c5, 0) - coalesce(b.c5, 0)), 19) IN (2,6,10,14)
+) t
+ORDER BY t.c2, t.c3;
+

--- a/sql/cost-validation-bucketized/queries/bucketized-group-by.sql
+++ b/sql/cost-validation-bucketized/queries/bucketized-group-by.sql
@@ -506,3 +506,137 @@ LIMIT 50000;
 SELECT m.c2, w.c3, t.c4 FROM t1000000m m JOIN t100000w w ON m.c2 = w.c2 JOIN t100000 t ON t.c2 = m.c2 AND t.c3 = w.c3
 WHERE ((m.c2 > m.c3 AND w.c4 IS NOT NULL AND t.c4 IS NOT NULL) OR (m.c2 = ANY (ARRAY[10010,10020,10030,10040,10050,10060,10070,10080]) AND m.c2 >= 10000 AND m.c2 <= 500000))
 ORDER BY m.c2, w.c3, t.c4;
+
+
+WITH src AS (
+    SELECT c1, c2
+    FROM t1000
+    WHERE c1 <> c2
+)
+SELECT
+    src.c1,
+    src.c2,
+    z.c5,
+    z.rnk
+FROM src,
+LATERAL (
+    SELECT *
+    FROM (
+        SELECT
+            m.c1,
+            m.c2,
+            m.c5,
+
+            rank() OVER (
+                ORDER BY m.c5 ASC
+            ) rnk,
+
+            row_number() OVER (
+                PARTITION BY m.c1
+                ORDER BY m.c5 ASC
+            ) rn
+
+        FROM t1000000m m
+        WHERE greatest(m.c5, src.c2) - least(m.c5, src.c2) < 25
+    ) sub
+    WHERE sub.rn <= 30
+) z
+WHERE z.rnk <= 20
+ORDER BY src.c1, src.c2;
+
+
+
+
+WITH src AS (
+    SELECT c1, c6
+    FROM t1000000m
+    WHERE c6 IS NOT NULL
+)
+SELECT
+    src.c1,
+    src.c6,
+    z.c4,
+    z.dr
+FROM src,
+LATERAL (
+    SELECT *
+    FROM (
+        SELECT
+            w.c1,
+            w.c4,
+            w.c6,
+
+            dense_rank() OVER (
+                ORDER BY w.c4 DESC
+            ) dr,
+
+            row_number() OVER (
+                PARTITION BY w.c1
+                ORDER BY w.c4 DESC
+            ) rn
+
+        FROM t100000w w
+        WHERE power(abs(w.c6 - src.c6), 2)::bigint % 17 IN (2,4,8,16)
+    ) sub
+    WHERE sub.rn <= 50
+) z
+WHERE z.dr <= 18
+ORDER BY src.c1, src.c6;
+
+
+WITH s AS (
+    SELECT c1, c6
+    FROM t1000000m
+    WHERE c6 > 0
+)
+SELECT
+    s.c1,
+    s.c6,
+    x.c3
+FROM s,
+LATERAL (
+    SELECT
+        c1,
+        c3
+    FROM t100000
+    WHERE c1 = s.c1
+      AND c3 NOT IN (
+          SELECT c3
+          FROM t100
+          WHERE c2 < c4
+      )
+      AND abs(c3 - coalesce(s.c6,0)) % 9 IN (1,5,7)
+      AND greatest(c3, coalesce(s.c6,0), 100) < 1000
+      AND least(c3, coalesce(s.c6,0), 10000) > 5
+      AND sqrt(abs(s.c6))::int >= 0
+) x
+ORDER BY s.c1, x.c3;
+
+
+WITH s AS (
+    SELECT c1, v
+    FROM t10000
+    WHERE v LIKE '___%'
+)
+SELECT
+    s.c1,
+    s.v,
+    x.c6
+FROM s,
+LATERAL (
+    SELECT
+        c1,
+        c6
+    FROM t1000000m
+    WHERE c1 = s.c1
+      AND c6 NOT IN (
+          SELECT c6
+          FROM t1000
+          WHERE c4 IS NULL
+      )
+      AND abs(c6 - coalesce(s.c1,0)) % 13 IN (2,6,10)
+      AND greatest(c6, coalesce(s.c1,0), 75) < 2500
+      AND least(c6, coalesce(s.c1,0), 100000) > 50
+      AND substr(s.v,1,1) = '_'
+) x
+ORDER BY s.c1, x.c6;

--- a/sql/cost-validation-bucketized/queries/bucketized-group-by.sql
+++ b/sql/cost-validation-bucketized/queries/bucketized-group-by.sql
@@ -771,3 +771,43 @@ LATERAL (
 ) z
 WHERE z.dr <= 24
 ORDER BY src.c1, src.c2;
+
+
+
+WITH src AS (
+    SELECT c1, c2
+    FROM t1000
+    WHERE c1 > c2
+)
+SELECT
+    src.c1,
+    src.c2,
+    z.c6,
+    z.dr
+FROM src,
+LATERAL (
+    SELECT *
+    FROM (
+        SELECT
+            w.c1,
+            w.c4,
+            w.c6,
+
+            dense_rank() OVER (
+                ORDER BY w.c6 ASC
+            ) dr,
+
+            row_number() OVER (
+                PARTITION BY w.c1
+                ORDER BY w.c6 ASC
+            ) rn
+
+        FROM t100000w w
+        WHERE abs(w.c6 - src.c2) % 47
+              IN (3,9,15,21,27,33)
+          AND greatest(w.c6, src.c2, 1) < 1000000
+    ) sub
+    WHERE sub.rn <= 45
+) z
+WHERE z.dr <= 26
+ORDER BY src.c1, src.c2;

--- a/sql/cost-validation-bucketized/queries/bucketized-group-by.sql
+++ b/sql/cost-validation-bucketized/queries/bucketized-group-by.sql
@@ -150,22 +150,6 @@ FROM (
 GROUP BY sub.c2
 ORDER BY sub.c2;
 
-WITH w_filtered AS (
-    SELECT c1, c2, v
-    FROM t100000w
-    WHERE bucketid IN (0,1,2) AND c1 > 0
-),
-m_filtered AS (
-    SELECT c1, c2, c3, c6
-    FROM t1000000m
-    WHERE c2 BETWEEN 100 AND 10000
-)
-SELECT wf.c2, count(*) AS cnt, avg(mf.c3) AS avg_c3, sum(mf.c6) AS sum_c6
-FROM w_filtered wf
-JOIN m_filtered mf ON wf.c1 = mf.c1 AND wf.c2 = mf.c2
-GROUP BY wf.c2
-ORDER BY wf.c2;
-
 
 SELECT c2,
        count(*) AS total,
@@ -406,3 +390,119 @@ SELECT c2,
 FROM t10000
 GROUP BY c2
 ORDER BY c2;
+
+
+SELECT DISTINCT ON (w.c2)
+    w.c2,
+    w.c3,
+    w.c4,
+    m.c6
+FROM t100000w w
+JOIN t1000000m m
+  ON m.c2 = w.c2
+WHERE w.c3 BETWEEN 100 AND 50000
+  AND m.c6 > 0
+ORDER BY w.c2, w.c4 DESC, m.c6 DESC;
+
+
+WITH RECURSIVE chains AS (
+    SELECT
+        c1,
+        c2,
+        c3,
+        1 AS depth
+    FROM t100
+    WHERE c2 BETWEEN 1 AND 20
+
+    UNION ALL
+
+    SELECT
+        t.c1,
+        t.c2,
+        t.c3,
+        c.depth + 1
+    FROM chains c
+    JOIN t1000 t
+      ON t.c2 = c.c2
+     AND t.c3 BETWEEN c.c3 - 5
+                  AND c.c3 + 5
+    WHERE c.depth < 6
+)
+SELECT
+    c2,
+    count(*) AS cnt,
+    avg(c3) AS avg_c3,
+    max(depth) AS max_depth
+FROM chains
+GROUP BY c2
+ORDER BY cnt DESC, c2
+LIMIT 100;
+
+
+
+
+SELECT
+    m.c2, w.c3, t.c4, s.c5,
+    rank() OVER (
+        PARTITION BY m.c2
+        ORDER BY w.c3 DESC, t.c4 DESC
+    ) AS rnk,
+
+    row_number() OVER (
+        PARTITION BY m.c2
+        ORDER BY s.c5 DESC
+    ) AS rn
+
+FROM t1000000m m
+JOIN t100000w w ON m.c2 = w.c2
+JOIN t100000 t
+  ON t.c2 = m.c2
+ AND t.c3 BETWEEN m.c3 - 50
+              AND m.c3 + 50
+JOIN t1000000m s
+  ON s.c2 = m.c2
+ AND s.c3 BETWEEN m.c3 - 20
+              AND m.c3 + 20
+WHERE
+(
+    m.c2 > m.c3
+    AND w.c4 IS NOT NULL
+)
+OR
+(
+    m.c2 = ANY (
+        ARRAY[
+            10010,
+            10020,
+            10030,
+            10040,
+            10050,
+            10060,
+            10070,
+            10080,
+            10090,
+            10100,
+            10110,
+            10120,
+            10130,
+            10140,
+            10150,
+            10160
+        ]
+    )
+
+    AND m.c2 >= 10000
+    AND m.c2 <= 500000
+    AND abs(m.c2) >= 10000
+)
+AND t.c4 IS NOT NULL AND s.c5 IS NOT NULL
+ORDER BY
+    m.c2, w.c3, t.c4 DESC, s.c5 DESC
+LIMIT 50000;
+
+
+
+
+SELECT m.c2, w.c3, t.c4 FROM t1000000m m JOIN t100000w w ON m.c2 = w.c2 JOIN t100000 t ON t.c2 = m.c2 AND t.c3 = w.c3
+WHERE ((m.c2 > m.c3 AND w.c4 IS NOT NULL AND t.c4 IS NOT NULL) OR (m.c2 = ANY (ARRAY[10010,10020,10030,10040,10050,10060,10070,10080]) AND m.c2 >= 10000 AND m.c2 <= 500000))
+ORDER BY m.c2, w.c3, t.c4;

--- a/sql/cost-validation-bucketized/queries/bucketized-group-by.sql
+++ b/sql/cost-validation-bucketized/queries/bucketized-group-by.sql
@@ -640,3 +640,134 @@ LATERAL (
       AND substr(s.v,1,1) = '_'
 ) x
 ORDER BY s.c1, x.c6;
+
+SELECT
+    w.c1,
+    w.c2,
+    w.c6,
+    t.c4
+FROM t100000w w
+JOIN t100000 t
+  ON t.c1 = w.c1
+ AND w.c6 IS NOT NULL
+ AND t.c4 > 0
+ORDER BY
+    w.c1 DESC,
+    w.c6 DESC;
+
+
+WITH src AS (
+    SELECT c1, c2
+    FROM t1000
+    WHERE c1 <> c2
+)
+SELECT
+    src.c1,
+    src.c2,
+    z.c5,
+    z.dr
+FROM src,
+LATERAL (
+    SELECT *
+    FROM (
+        SELECT
+            m.c1,
+            m.c2,
+            m.c5,
+
+            dense_rank() OVER (
+                ORDER BY m.c5 ASC
+            ) dr,
+
+            row_number() OVER (
+                PARTITION BY m.c1
+                ORDER BY m.c5 ASC
+            ) rn
+
+        FROM t1000000m m
+        WHERE greatest(m.c5, src.c2) - least(m.c5, src.c2) < 100
+          AND mod(m.c5 + src.c2, 17) IN (1,5,9,13)
+    ) sub
+    WHERE sub.rn <= 40
+) z
+WHERE z.dr <= 22
+ORDER BY src.c1, src.c2;
+
+
+
+WITH src AS (
+    SELECT c1, c5
+    FROM t1000000m
+    WHERE c5 IS NOT NULL
+)
+SELECT
+    src.c1,
+    src.c5,
+    z.c3,
+    z.dr
+FROM src,
+LATERAL (
+    SELECT *
+    FROM (
+        SELECT
+            w.c1,
+            w.c3,
+            w.c5,
+
+            dense_rank() OVER (
+                ORDER BY w.c3 DESC
+            ) dr,
+
+            row_number() OVER (
+                PARTITION BY w.c1
+                ORDER BY w.c3 DESC
+            ) rn
+
+        FROM t100000w w
+        WHERE mod(abs(w.c5 - src.c5), 19) IN (1,5,9,13,17)
+    ) sub
+    WHERE sub.rn <= 50
+) z
+WHERE z.dr <= 20
+ORDER BY src.c1, src.c5;
+
+
+
+
+WITH src AS (
+    SELECT c1, c2
+    FROM t1000
+    WHERE c1 <> c2
+)
+SELECT
+    src.c1,
+    src.c2,
+    z.c5,
+    z.dr
+FROM src,
+LATERAL (
+    SELECT *
+    FROM (
+        SELECT
+            m.c1,
+            m.c2,
+            m.c5,
+
+            dense_rank() OVER (
+                ORDER BY m.c5 ASC
+            ) dr,
+
+            row_number() OVER (
+                PARTITION BY m.c1
+                ORDER BY m.c5 ASC
+            ) rn
+
+        FROM t1000000m m
+        WHERE abs(m.c5 - src.c2) % 17
+              IN (1,5,9,13)
+          AND greatest(m.c5, src.c2, 0) < 100000
+    ) sub
+    WHERE sub.rn <= 40
+) z
+WHERE z.dr <= 24
+ORDER BY src.c1, src.c2;

--- a/sql/cost-validation-bucketized/queries/table-bucketized-index-queries.sql
+++ b/sql/cost-validation-bucketized/queries/table-bucketized-index-queries.sql
@@ -44,7 +44,6 @@ SELECT c1, c2, row_number() OVER (ORDER BY c1, c2) AS rn FROM table_bucketized W
 SELECT t1.c1, t1.c2, t2.c4 FROM table_bucketized t1 JOIN table_bucketized t2 ON t1.c2 = t2.c2 WHERE t1.c2 BETWEEN 5 AND 500 limit 100;
 SELECT m.c1, m.c2, t.c3 FROM table_bucketized m JOIN table_bucketized t ON m.c1 = t.c1 WHERE m.c2 > m.c1 limit 10;
 SELECT t1.c1, t1.c2, t1.c4, t2.c3 FROM table_bucketized t1 JOIN table_bucketized t2 ON t1.c2 = t2.c2 WHERE t1.c4 BETWEEN 20 AND 80 order by t1.c1, t1.c4;
-SELECT big.c1, big.c2, small.c3 FROM table_bucketized big JOIN table_bucketized small ON small.c1 = big.c1 AND small.c2 = big.c2 WHERE big.c1 > big.c2 ORDER BY big.c1, big.c2 limit 10;
 SELECT m.c1, m.c2, m.c3, t.c4 FROM table_bucketized t JOIN table_bucketized m ON m.c1 = t.c1 AND m.c3 = t.c3 WHERE greatest(m.c1, m.c3) = m.c1 and m.c2=10 ORDER BY m.c1, m.c3;
 SELECT m.c1, m.c2, w.v FROM table_bucketized w JOIN table_bucketized m ON m.c1 = w.c1 AND m.c2 = w.c2 WHERE sign(w.c1 - w.c2) = 1 and m.c2=10 ORDER BY w.c1, w.c2;
 SELECT m.c1, m.c2, w.v, t.c3 FROM table_bucketized m JOIN table_bucketized w ON w.c1 = m.c1 AND abs(w.c2 - m.c2) = 0 and m.c1=100 JOIN table_bucketized t ON t.c2 = m.c2 WHERE sign(m.c1 - m.c2) >= 0 ORDER BY m.c1, m.c2;

--- a/sql/cost-validation-bucketized/queries/table-simple-index-queries.sql
+++ b/sql/cost-validation-bucketized/queries/table-simple-index-queries.sql
@@ -44,9 +44,7 @@ SELECT c1, c2, row_number() OVER (ORDER BY c1, c2) AS rn FROM table_simple WHERE
 SELECT t1.c1, t1.c2, t2.c4 FROM table_simple t1 JOIN table_simple t2 ON t1.c2 = t2.c2 WHERE t1.c2 BETWEEN 5 AND 500 limit 100;
 SELECT m.c1, m.c2, t.c3 FROM table_simple m JOIN table_simple t ON m.c1 = t.c1 WHERE m.c2 > m.c1 limit 10;
 SELECT t1.c1, t1.c2, t1.c4, t2.c3 FROM table_simple t1 JOIN table_simple t2 ON t1.c2 = t2.c2 WHERE t1.c4 BETWEEN 20 AND 80 order by t1.c1, t1.c4;
-SELECT big.c1, big.c2, small.c3 FROM table_simple big JOIN table_simple small ON small.c1 = big.c1 AND small.c2 = big.c2 WHERE big.c1 > big.c2 ORDER BY big.c1, big.c2 limit 10;
 SELECT m.c1, m.c2, m.c3, t.c4 FROM table_simple t JOIN table_simple m ON m.c1 = t.c1 AND m.c3 = t.c3 WHERE greatest(m.c1, m.c3) = m.c1 and m.c2=10 ORDER BY m.c1, m.c3;
-SELECT m.c1, m.c2, w.v FROM table_simple w JOIN table_simple m ON m.c1 = w.c1 AND m.c2 = w.c2 WHERE sign(w.c1 - w.c2) = 1 and m.c2=10 ORDER BY w.c1, w.c2;
 SELECT m.c1, m.c2, w.v, t.c3 FROM table_simple m JOIN table_simple w ON w.c1 = m.c1 AND abs(w.c2 - m.c2) = 0 and m.c1=100 JOIN table_simple t ON t.c2 = m.c2 WHERE sign(m.c1 - m.c2) >= 0 ORDER BY m.c1, m.c2;
 SELECT m.c1, m.c2, w.v FROM table_simple m JOIN table_simple w ON w.c1 = m.c1 AND abs(w.c2 - m.c2) = 0 WHERE (m.c3 IN (5, 10, 15) OR m.c4 BETWEEN 100 AND 200) AND m.c1 >= m.c2 ORDER BY m.c1, m.c2 limit 10;
 SELECT a.c1, a.c2, b.c3 FROM table_simple a JOIN table_simple b ON a.c1 = b.c1 AND a.c2 = b.c2 WHERE a.c1 > a.c2 AND b.c1 < b.c2 + 10 and b.c1=20 and a.c1=10 ORDER BY a.c1, a.c2;


### PR DESCRIPTION
- Removed certain queries that had plans never being executed
- Added few queries testing multiple conditions targetting same columns
- Added few more longer running queries (50ms-5000ms, some even more)
- Added queries that take multiple loops on bucketized index rather than other queries

Example - 
```
->  Index Scan using t100000w_pkey on t100000w w  (cost=25.01..614.17 rows=100 width=8) (actual time=8.523..9.375 rows=1290 loo
ps=513)
       Index Cond: (bucketid = ANY ('{0,1,2,3,4,5,6,7,8,9,10}'::integer[]))
       Merge Sort Key: w.c1
       Merge Stream Key: w.bucketid
       Merge Streams: 11
       Storage Filter: ((abs((c6 - t1000.c2)) % 47) = ANY ('{3,9,15,21,27,33}'::integer[]))
       Filter: (GREATEST(c6, t1000.c2, 1) < 1000000)
Planning Time: 0.320 ms
Execution Time: 7416.059 ms
Peak Memory Usage: 4105 kB
```
and some
```
->  Sort  (cost=623.87..624.50 rows=250 width=16) (actual time=17.026..17.028 rows=35 loops=1000)
      Sort Key: w.c3 DESC
      Sort Method: quicksort  Memory: 240kB
      ->  WindowAgg  (cost=608.91..613.91 rows=250 width=16) (actual time=10.738..16.263 rows=2632 loops=1000)
            Run Condition: (row_number() OVER (?) <= 50)
            ->  Sort  (cost=608.91..609.54 rows=250 width=8) (actual time=10.731..10.919 rows=2632 loops=1000)
                  Sort Key: w.c1, w.c3 DESC
                  Sort Method: quicksort  Memory: 220kB
                  ->  Index Scan using t100000w_pkey on t100000w w  (cost=24.58..598.96 rows=250 width=8) (actual time=8.582..10.230 
rows=2632 loops=1000)
                        Index Cond: (bucketid = ANY ('{0,1,2,3,4,5,6,7,8,9,10}'::integer[]))
                        Merge Sort Key: w.c1
                        Merge Stream Key: w.bucketid
                        Merge Streams: 11
                        Storage Filter: (mod(abs((c5 - t1000000m.c5)), 19) = ANY ('{1,5,9,13,17}'::integer[]))
```