### PR TITLE
Add --query-hash flag to run a single query in collect

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -101,6 +101,7 @@ class Config(metaclass=Singleton):
     look_near_best_plan: bool = None
 
     num_queries: int = None
+    query_hash: str = None
     parametrized: bool = False
     num_retries: int = None
     num_warmup: int = None

--- a/src/models/sql.py
+++ b/src/models/sql.py
@@ -350,6 +350,10 @@ class SQLModel(QTFModel):
                                 tables=tables_in_query,
                                 optimizer_tips=current_tips))
 
+        if self.config.query_hash:
+            queries = [query for query in queries
+                       if query.query_hash == self.config.query_hash]
+
         if self.config.num_queries > 0:
             queries = queries[:int(self.config.num_queries)]
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -240,6 +240,9 @@ if __name__ == "__main__":
     parser.add_argument('--num-queries',
                         default=-1,
                         help='Number of queries to evaluate')
+    parser.add_argument('--query-hash',
+                        default=None,
+                        help='Evaluate only the single query matching this query hash')
     parser.add_argument('--parametrized',
                         action=argparse.BooleanOptionalAction,
                         default=False,
@@ -357,6 +360,7 @@ if __name__ == "__main__":
 
         num_queries=int(args.num_queries)
         if args.num_queries is not None else configuration.get("num-queries", -1),
+        query_hash=args.query_hash,
         num_retries=int(configuration.get("num-retries", 5)),
         num_warmup=int(configuration.get("num-warmup", 1)),
 


### PR DESCRIPTION
## What

Adds the ability to evaluate only a single query in the `collect` action, identified by its query hash.

## Why

Useful for debugging or re-running one specific query without collecting the entire model.

## Changes

- `src/config.py` — new `query_hash` config field
- `src/runner.py` — new `--query-hash` CLI arg, wired into `Config`
- `src/models/sql.py` — `get_queries()` filters the query list to the matching hash when set (applied before the `--num-queries` truncation)

## Usage

```
python src/runner.py collect --model <model> --output <name> --query-hash <hash>
```

## Notes

- Defaults to `None` → current behavior unchanged when the flag is unused.
- Filter mirrors the existing `--num-queries` mechanism.

---
_automated · Claude Code (Opus 4.8)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
