### PR TITLE
Add cost-validation-bucketized-v2

### DIFF
--- a/sql/cost-validation-bucketized-v2/README.md
+++ b/sql/cost-validation-bucketized-v2/README.md
@@ -1,0 +1,284 @@
+# cost-validation-bucketized-v2
+
+A part of the cost-validation-xxx model series, covering merge scan and the
+two derived-clause GUCs that sit alongside it.  It replaces
+`cost-validation-bucketized`, which treated all three as one feature.
+
+## What this model is for
+
+Three planner GUCs drive what people call the bucketized-index feature, they
+default to on, and they fail in different ways.  The old model mixed them into
+the same tables and query files, so a finding could not be attributed to one
+of them.  Here each query file targets exactly one, and the file name says
+which:
+
+| prefix | GUC under test |
+|---|---|
+| `merge-*` | `yb_max_merge_scan_streams` |
+| `saop-*` | `yb_enable_derived_saops` |
+| `eq-*` | `yb_enable_derived_equalities` |
+| `rival-*` | the deliberately thin alternative-index suite, see below |
+
+**Merge scan** is the main effort.  The cost model's only merge-specific
+behavior today is multiplying the plain scan cost by 1.02 as a tie-breaker
+placeholder (yugabyte/yugabyte-db#29078), so it charges the same for 2 streams
+as for 64 while the executor's work grows with the count.  The instrument for
+that is a controlled bucket-count sweep, which the old model had no equivalent
+of.
+
+**Derived SAOPs** can no longer regress a plan with no merge in it, since they
+only attach to merge scan index paths, and the planner keeps the path without
+the derivation alongside the one with it.  What is left to test is that cost
+comparison.  Findings from it may not be merge-scan-specific at all: an index
+scan preferred on the strength of a condition that passes every row is the
+general symptom in #32317.
+
+**Derived equalities** have open defects: no path without the derivation is
+generated, so the CBO never gets a choice (#31164), and the derived expression
+is never const-folded, so it becomes a runtime key and puts a spurious recheck
+on bitmap scans (#31354).
+
+## Design rules
+
+1. **Hot-shard rule.**  A bucketized index exists because the plain range
+   index on the same leading columns would concentrate every insert on one
+   shard.  A deployment that has taken that trouble does not also keep the hot
+   index.  So where a bucketized entity orders by `c1`, no plain index leading
+   with `c1` exists on that table.  Plain indexes on non-monotone columns are
+   allowed and used, because they are what a real schema has and they give the
+   CBO a genuine rival.  `riv` and `rivb` break the rule on purpose and are
+   the only tables that do.
+2. **Bucketize what would actually be hot.**  `c1` is a monotone "event time"
+   and is what every bucketized entity orders by.
+3. **GUC-neutral query files.**  There is not a single `SET` in `queries/`.
+   Comparison is done by running `collect` more than once with different
+   database-level settings, per the matrix below.  This also avoids the leak
+   the old model has, where `set enable_seqscan to false` in
+   `bucketized-simple.sql` silently applies to every later query in that file.
+4. **No user-written full-domain IN on a bucket column** except in
+   `saop-02`, which exists to document that it is unstable (#33251).  Everywhere
+   else the derivation is left to the planner.
+5. **Every bucketized entity is pre-split at bucket boundaries**, the intended
+   one-tablet-per-bucket layout, so measurements are not dominated by #33247.
+   A base table whose primary key is not bucketized gets 4 tablets so a
+   sequential scan is not artificially serialized.  Plain secondary indexes
+   are left at the YB default of one tablet, which is what a user gets, and
+   the files say where that makes a query #33247-exposed.
+6. **Controlled pairs everywhere.**  Tables of the same row count hold
+   identical data, so a difference between two results is a schema difference
+   and never a data difference.
+
+## Prerequisites
+
+Merge scan requires the cost-based optimizer.  The database must have
+`yb_enable_cbo = on` before any query runs, and the model does not set it,
+because the GUC has been renamed once already and pinning it in a query file
+would break on older and newer builds alike.  Set it on the database or
+through `ysql_pg_conf_csv` on the tservers.  `ALTER DATABASE ... SET` takes
+effect for new connections only.
+
+## How to run
+
+Load once, then run `collect` for each GUC setting with `--ddls=none` so the
+data is untouched between legs:
+
+```
+python3 src/runner.py collect --model=cost-validation-bucketized-v2 \
+  --config=config/default.conf --database=taqo --output=bktv2_on
+# then, per leg: ALTER DATABASE taqo SET <guc> = <value>;
+python3 src/runner.py collect --model=cost-validation-bucketized-v2 \
+  --config=config/default.conf --database=taqo --ddls=none --output=bktv2_off
+python3 src/runner.py report --type=regression --config=config/default.conf \
+  --v1-results=report/bktv2_off.json --v2-results=report/bktv2_on.json
+```
+
+The legs worth taking, in order of value:
+
+| leg | settings |
+|---|---|
+| everything on | defaults |
+| merge scan off | `yb_max_merge_scan_streams = 0` (this also disables derived SAOPs) |
+| derived SAOPs off | `yb_enable_derived_saops = off` |
+| derived equalities off | `yb_enable_derived_equalities = off` |
+| stream cap below the bucket count | `yb_max_merge_scan_streams = 15`, which removes merge scan from every 16-bucket table without touching the 2, 4 and 8 bucket ones |
+
+For the cost report rather than a regression comparison, use
+`--type=cost`.  Note that its index-key extraction assumes an index named
+`<table>_<packed key columns>`, which this model follows, but it maps any
+`_pkey` to a single key column `c1`, so column-position metrics on the
+bucketized primary keys are not meaningful.
+
+## Schema
+
+Column roles are the same in every table:
+
+| col | role |
+|---|---|
+| `c0` | bucket, `generated always as (yb_hash_code(...) % B) stored` |
+| `c1` | monotone 1..N, the "event time", what bucketized entities order by |
+| `c2` | unique permutation of 1..N, the "entity id", the hash input |
+| `c3` | ndv 1000 |
+| `c4` | ndv 100 |
+| `c5` | unique permutation, never indexed |
+| `c6` | ndv 10 |
+| `c7` | ndv 100 |
+| `c8` | `c7` in every row but the first, where it is `c7 + 1` |
+| `v` | `char(64)`, or `char(4096)` on `mw16` |
+
+| table | rows | tablets | why it exists |
+|---|---|---|---|
+| `mb2` `mb4` `mb16` `mb64` | 500 K each | 2 / 4 / 16 / 64 | the sweep: identical data, PK `(c0, c1, c2)`, no other index |
+| `mplain` | 500 K | 16 | the sweep's control: same rows, PK `(c1)`, no streams |
+| `mn16` `mw16` | 50 K each | 16 | the width pair, `char(64)` against `char(4096)` |
+| `ms16` | 300 K | 16 | PK `(c0, c6, c1)`: streams are 16 x the IN list, crossing the 64 cap |
+| `sa` | 500 K | 4 | no bucketization at all, indexes on `(c6,c1)`, `(c4,c1)`, `(c3,c1)`: merge scan on user IN lists, isolated from both derived GUCs |
+| `sel` | 500 K | 16 | bucketized PK plus selective plain indexes on `c3`, `c7`, `v`: the LIMIT bet against a real rival |
+| `pt` | 200 K | 4 x 8 | range partitioned by `c1` over a bucketized PK |
+| `dj` | 20 K | 4 | join partner, `c1` and `c2` both cover 1..20000 |
+| `de16` | 500 K | 16 | derived equalities, one-column generation expression |
+| `de2c` | 300 K | 8 | two-column generation expression: partial against full derivation |
+| `dex` | 300 K | 4 | expression indexes, no generated column |
+| `riv` | 500 K | 4 | `sa` plus a plain `(c1)` and a covering `(c1, c6)` |
+| `rivb` | 500 K | 16 | `mb16` plus a covering plain `(c1, c2)` |
+
+6.22 M rows, measured at 1954 MB of logical size including indexes on a
+freshly loaded cluster.  The old model loads about a third fewer rows but
+most of them carry a 1 KB or 8 KB payload, so it is several times heavier.
+`analyze.sql` creates no extended statistics on purpose: a statistics object
+over `c7` and `c8` would remove the estimate error the model is built to
+sweep.
+
+## Query suites
+
+665 queries in 17 files.
+
+**Merge scan.**
+`merge-01-bucket-sweep` repeats one query grid across all four bucket counts
+and the control.  `merge-02-limit-and-aggregates` sweeps LIMIT across the
+1024-row fetch page and then removes the LIMIT from the scan's reach.
+`merge-03-width` is the width pair.  `merge-04-user-inlist` is merge scan on
+user-written IN lists with no bucketization anywhere, each paired with a
+`BETWEEN` twin that selects the same rows and cannot merge.
+`merge-05-stream-product` multiplies the derived bucket SAOP by a user IN
+list, across the cap.  `merge-06-order-shapes` varies who is buying the
+ordering.  `merge-07-limit-bets` is described below.  `merge-08-joins` puts
+the merge inside joins, and `merge-09-partitioned` under an Append.
+
+**Derived SAOPs.**  `saop-01-arbitration` pairs queries where the derivation
+earns its cost with queries where nothing above the scan wants an order.
+`saop-02-user-vs-derived` writes out the condition the planner would derive,
+documenting #33251.  `saop-03-join-order-flip` reproduces #32317: with the GUC
+on the plan is a batched nested loop whose outer is a 16-stream merge over
+`mw16` with the filter attached, and with it off the plan drives from `dj`.
+
+**Derived equalities.**  `eq-01-point-and-range` is the lookup that only works
+if the bucket is derived.  `eq-02-joins` is the same on the inner side of a
+nested loop, which is where the derivation is not an optimization but the
+thing that makes the schema usable.  `eq-03-or-and-bitmap` covers the separate
+OR-arm derivation path and the #31354 runtime key.  `eq-04-derivation-overhead`
+is #31164: derivations that add binds without narrowing anything, and streams
+planned that bind-time pruning removes.
+
+**Rival index.**  `rival-01-alt-index` is the one file where a plain ordered
+index on the sort column coexists with the bucketized entity.  It is thin on
+purpose: a deployment that bucketized to escape a hot shard does not keep the
+hot index, and an honest per-stream cost model handles this case as a
+byproduct of getting the streams right.  It is here because the configuration
+does occur in half-migrated schemas and in benchmark models, and because the
+right answer is unambiguous.
+
+### About `merge-07-limit-bets`
+
+The largest regression the old model finds is `v LIKE 'zz%' ORDER BY c1, c2
+LIMIT 10`, at 1349x: a 3-stream merge with the LIKE as a storage filter costed
+at 124 against 2851 for a selective index scan plus a sort, then scanning all
+1000000 rows to return nothing.
+
+It is tempting to read that as a bug about empty results.  It is not.  In that
+run the regression rate is flat across output sizes, 29 % of queries returning
+no rows, 31 % returning one, 30 % returning 11 to 100, 29 % returning 101 to
+10000, falling away only above 10000 rows.  Returning nothing does not cause
+the wrong plan, it removes the early exit that would have hidden it.  So this
+file sweeps the estimate error rather than camping on the corner.  `c8` equals
+`c7` in every row but the first, and with no extended statistics the estimator
+predicts about 50 rows for all three of these:
+
+| predicate | actual rows | estimate is |
+|---|---|---|
+| `c7 = 2 AND c8 = 2` | 4999 | about 100x too low |
+| `c7 = 2 AND c8 = 3` | 1 | about 50x too high |
+| `c7 = 50 AND c8 = 51` | 0 | infinitely too high |
+
+Each runs against `sel`, where a selective rival path exists and the question
+is whether the CBO picks it, against `mb16`, where the merge is the only path
+and the question is what the bad bet costs, and against `mplain`, the floor.
+
+## Writing queries for this model
+
+Three constraints come from the framework's parser in `src/models/sql.py`:
+
+- Queries are split on `;` before comments are stripped, so a semicolon must
+  never appear inside a comment.
+- `sqlparse.format(..., strip_comments=True)` removes `/*+ ... */`, so
+  pg_hint_plan hints cannot be embedded in a query file.
+- A bare `SET` becomes a debug query applied to every later query in the same
+  file, with no way to scope it.  This model has none.
+
+A join query must use aliases for every table or for none.
+
+## Issue index
+
+| issue | what it is | where it shows |
+|---|---|---|
+| #29078 | merge scan costing is a 1.02 placeholder | `merge-01`, `merge-02`, `merge-03`, `merge-05` |
+| #31163 | decouple derived SAOPs from merge scan | widens `saop-01` when it lands |
+| #31164 | no non-derived path is generated | `eq-04` |
+| #31354 | derived expressions are not const-folded | `eq-03`, visible in every `eq-*` plan |
+| #32317 | index scan preferred on a 100 %-passing condition | `saop-01`, `saop-03` |
+| #33247 | streams sharing a tablet split one response budget | flagged in `merge-04` and `merge-05` |
+| #33251 | full-domain IN estimate flips across ANALYZE runs | `saop-02` |
+
+## Verified
+
+Against a single-node RF1 cluster on release binaries, version string
+`PostgreSQL 15.12-YB-2.31.0.0-b0`, build revision
+`5eae1e456c2198a7a50b6db33cb225bee674e17b`, with `yb_enable_cbo = on`:
+
+- `create.sql`, `import.sql` and `analyze.sql` apply with no errors, and every
+  pre-split entity reports the intended tablet count through
+  `yb_table_properties`: 2, 4, 16 and 64 across the sweep, 16 for the other
+  16-bucket tables and for the `mplain` control, 8 for `de2c`, for each `pt`
+  partition and for both bucketized indexes on `dex`, 4 for the base tables
+  whose primary key is not bucketized, and 1 for every plain secondary index.
+- `postgres.create.sql` applies without error as a syntax check, though on YB
+  rather than on upstream.
+- All 665 queries pass `EXPLAIN (VERBOSE, COSTS OFF)` with no errors.  336 of
+  them produce a merge scan, 70 produce a derived-equality index condition,
+  and 26 produce a bitmap plan.  No query mixes aliased and unaliased tables.
+- All 665 also pass `EXPLAIN (ANALYZE, DIST)` with no errors, one pass costing
+  74 seconds of wall time and 30.6 seconds of measured execution.  The slowest
+  single query is 1.1 seconds.  At the framework's default of one warmup plus
+  five retries, a `collect` run should be well inside 15 minutes of query time.
+- Every data fact this README and the query comments assert was checked
+  against the loaded data: the `c7`/`c8` ladder at 4999, 1 and 0 rows,
+  `length(v)` constant at 64 with `LIKE 'zz%'` matching nothing and
+  `LIKE '--%'` matching all 500000, ndv of 1000, 100 and 10 on `c3`, `c4` and
+  `c6`, bucket occupancy even to within 2.5 % at 64 buckets, `mb16` and
+  `mplain` holding byte-identical rows, and `dj` matching 20000 rows on both
+  `c1` and `c2`.
+
+Three findings the instrument produced on that build, recorded because they
+show it is measuring what it was built to measure rather than because they are
+conclusions:
+
+- `SELECT c1, c2 FROM mb64 ORDER BY c1 LIMIT 1000` scans 64000 rows against
+  `mplain`'s 1000 for the same result, because every stream is handed the full
+  LIMIT.  The cost model prices the two within 2 % of each other.
+- On `rivb`, whose covering plain `(c1, c2)` index answers `ORDER BY c1 LIMIT
+  10` by scanning 10 rows, the CBO prefers the 16-stream merge over the
+  bucketized primary key at cost 22.34 against 51.13, and that plan scans 160.
+- The #32317 join-order flip reproduces exactly: with derived SAOPs on, the
+  plan is a batched nested loop whose outer is a 16-stream merge over `mw16`
+  with the opaque filter attached, estimated at 3499, and with them off it
+  drives from `dj` and reaches `mw16` through a derived-equality index
+  condition, estimated at 5946.

--- a/sql/cost-validation-bucketized-v2/analyze.sql
+++ b/sql/cost-validation-bucketized-v2/analyze.sql
@@ -1,0 +1,32 @@
+-- No extended statistics anywhere in this model, on purpose.
+--
+-- A statistics object on (c7, c8) would teach the estimator that the two
+-- columns are identical and remove the misestimate that the impossible-twin
+-- queries in merge-07 exist to exercise.  Objects on the bucket column would
+-- likewise mask how the derived and user-written forms of the same condition
+-- are estimated differently (yugabyte/yugabyte-db#33251).  The model's job is
+-- to measure the cost model on the estimates a plain ANALYZE produces, so
+-- that is all it takes.
+
+analyze mb2;
+analyze mb4;
+analyze mb16;
+analyze mb64;
+analyze mplain;
+analyze mn16;
+analyze mw16;
+analyze ms16;
+analyze sel;
+analyze sa;
+analyze dj;
+analyze de16;
+analyze de2c;
+analyze dex;
+analyze riv;
+analyze rivb;
+
+analyze pt_p1;
+analyze pt_p2;
+analyze pt_p3;
+analyze pt_p4;
+analyze pt;

--- a/sql/cost-validation-bucketized-v2/create.sql
+++ b/sql/cost-validation-bucketized-v2/create.sql
@@ -1,0 +1,339 @@
+-- Schema for the cost-validation-bucketized-v2 model.  See README.md for the
+-- design rules this file follows.  The two that shape every statement below:
+--
+-- 1. Hot-shard rule.  A bucketized index exists because the plain range index
+--    on the same leading columns would concentrate writes on one shard.  So
+--    where a bucketized entity orders by c1, no plain index leading with c1
+--    exists on the same table.  The rival-suite tables (riv, rivb) break this
+--    on purpose and are the only ones that do.
+--
+-- 2. Layout rule.  Every bucketized entity is pre-split at bucket boundaries,
+--    which is the feature's intended one-tablet-per-bucket layout and keeps
+--    measurements off yugabyte/yugabyte-db#33247.  A base table whose primary
+--    key is not bucketized is pre-split into 4 tablets so a sequential scan
+--    is not artificially serialized against merge scan.  Plain secondary
+--    indexes are left at the YB default of one tablet, which is what a user
+--    actually gets.
+--
+-- Column roles are the same in every table:
+--   c0  bucket, generated always as (yb_hash_code(...) % B) stored
+--   c1  monotone 1..N, the "event time", what bucketized entities order by
+--   c2  unique permutation of 1..N, the "entity id", the hash input
+--   c3  ndv 1000, independent permutation
+--   c4  ndv 100, independent permutation
+--   c5  unique permutation, never indexed
+--   c6  ndv 10, independent permutation
+--   c7  ndv 100
+--   c8  equal to c7 in every row but the first, where it is c7 + 1, giving
+--       predicate pairs that match 4999 rows, exactly 1 row, or nothing while
+--       the estimator predicts about 50 for all three
+--   v   char(64), or char(4096) on the one wide table
+
+
+-- =====================================================================
+-- Merge scan: bucket count sweep
+-- =====================================================================
+-- mb2, mb4, mb16 and mb64 hold identical data and differ only in the
+-- modulus, so the stream count is the only variable across them.  Each has
+-- no index besides its bucketized primary key, so an ORDER BY c1 query has
+-- merge scan or a sort over a full scan and nothing else.
+
+create table mb2 (
+  c0 int generated always as (yb_hash_code(c2) % 2) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0 asc, c1 asc, c2 asc)
+) split at values ((1));
+
+create table mb4 (
+  c0 int generated always as (yb_hash_code(c2) % 4) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0 asc, c1 asc, c2 asc)
+) split at values ((1),(2),(3));
+
+create table mb16 (
+  c0 int generated always as (yb_hash_code(c2) % 16) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0 asc, c1 asc, c2 asc)
+) split at values ((1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15));
+
+create table mb64 (
+  c0 int generated always as (yb_hash_code(c2) % 64) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0 asc, c1 asc, c2 asc)
+) split at values ((1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63));
+
+-- Control for the sweep: the same rows in the layout a user would have if c1
+-- were not hot enough to need bucketing.  One ordered scan, no streams.  It
+-- gets 16 tablets to match mb16, the reference point of the sweep.
+create table mplain (
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c1 asc)
+) split at values ((31250),(62500),(93750),(125000),(156250),(187500),(218750),(250000),(281250),(312500),(343750),(375000),(406250),(437500),(468750));
+
+
+-- =====================================================================
+-- Merge scan: row width
+-- =====================================================================
+-- mn16 and mw16 are the same table at two row widths, 64 characters against
+-- 4096, with the same 50000 rows.  Per-stream fetches are what row width
+-- makes expensive, and the pair isolates width with nothing else moving.
+-- mn16 is also the same schema as mb16 at a tenth of the rows, so the two
+-- pairs together separate width from row count.
+
+create table mn16 (
+  c0 int generated always as (yb_hash_code(c2) % 16) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0 asc, c1 asc, c2 asc)
+) split at values ((1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15));
+
+create table mw16 (
+  c0 int generated always as (yb_hash_code(c2) % 16) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(4096),
+  primary key (c0 asc, c1 asc, c2 asc)
+) split at values ((1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15));
+
+
+-- =====================================================================
+-- Merge scan: stream cardinality as a product
+-- =====================================================================
+-- The stream count is the cartesian product of every merge-eligible SAOP, so
+-- a user IN list on c6 multiplies the 16 derived bucket streams.  ndv(c6) is
+-- 10, giving products of 16, 32, ... 160 across the 64 cap.
+
+create table ms16 (
+  c0 int generated always as (yb_hash_code(c2) % 16) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0 asc, c6 asc, c1 asc)
+) split at values ((1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15));
+
+
+-- =====================================================================
+-- Merge scan: user-written IN lists, no bucketization anywhere
+-- =====================================================================
+-- Merge scan is not a bucketized-index feature.  Any range index plus a user
+-- IN list on its leading column engages it, and that is the majority of the
+-- exposure in existing workloads.  sa has no bucket column and no derived
+-- clause of any kind can apply to it, so it isolates merge scan from both
+-- derived-clause GUCs.  Its secondary indexes are deliberately left unsplit
+-- because that is the YB default a user gets, which also makes the large IN
+-- lists on sa_c4c1 the model's #33247 exposure.
+
+create table sa (
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c2 asc)
+) split at values ((125000),(250000),(375000));
+
+-- Three lead columns of different cardinality, so a user IN list can produce
+-- anything from 2 streams to more than the 64 cap, at selectivities from a
+-- tenth of the table per element down to a thousandth.
+create index sa_c6c1 on sa (c6 asc, c1 asc);
+create index sa_c4c1 on sa (c4 asc, c1 asc);
+create index sa_c3c1 on sa (c3 asc, c1 asc);
+
+
+-- =====================================================================
+-- Merge scan: estimate error against a selective rival path
+-- =====================================================================
+-- The same rows as mb16 with three plain indexes on columns a filter can
+-- actually seek on.  None of the three leads with c1, so the hot-shard rule
+-- holds: c3, c7 and v are all non-monotone and a plain index on them is what
+-- a real schema would have.  What that buys is a genuine competitor for every
+-- query here, an index condition that removes most of the table, against the
+-- bucketized primary key's derived condition that removes none of it.
+--
+-- This is the configuration behind the largest regressions the old model
+-- finds.  A merge scan ordered by c1 with the filter pushed down as a storage
+-- filter is priced on the assumption that the LIMIT stops it early, and it
+-- wins against a selective index scan plus a sort.  Whether that assumption
+-- holds depends entirely on how wrong the row estimate is, which is the axis
+-- merge-07 sweeps.
+--
+-- c7 and c8 are the instrument for that sweep.  c8 equals c7 in every row but
+-- one, so with no extended statistics the estimator predicts about 50 rows
+-- for any c7 = j AND c8 = k pair while the truth is 4999, 1 or 0 depending on
+-- which pair is asked for.
+create table sel (
+  c0 int generated always as (yb_hash_code(c2) % 16) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0 asc, c1 asc, c2 asc)
+) split at values ((1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15));
+
+create index sel_c3c1 on sel (c3 asc, c1 asc);
+create index sel_c7c1 on sel (c7 asc, c1 asc);
+create index sel_vc1 on sel (v asc, c1 asc);
+
+
+-- =====================================================================
+-- Merge scan: partitioning
+-- =====================================================================
+-- Time-range partitioning on top of a bucketized primary key is a realistic
+-- combination, and it puts a merge scan under each Append/MergeAppend child.
+-- The primary key must contain the partition key, which c1 satisfies.
+
+create table pt (
+  c0 int generated always as (yb_hash_code(c2) % 8) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0 asc, c1 asc, c2 asc)
+) partition by range (c1);
+
+create table pt_p1 partition of pt for values from (1) to (50001) split at values ((1),(2),(3),(4),(5),(6),(7));
+create table pt_p2 partition of pt for values from (50001) to (100001) split at values ((1),(2),(3),(4),(5),(6),(7));
+create table pt_p3 partition of pt for values from (100001) to (150001) split at values ((1),(2),(3),(4),(5),(6),(7));
+create table pt_p4 partition of pt for values from (150001) to (200001) split at values ((1),(2),(3),(4),(5),(6),(7));
+
+
+-- =====================================================================
+-- Join partner
+-- =====================================================================
+-- Small enough to be an obvious build or outer side, indexed on the join keys
+-- so the planner has a real choice of join order.  No bucket column: this
+-- table is the other side of the join, not a subject of the feature.
+
+create table dj (
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c2 asc)
+) split at values ((5000),(10000),(15000));
+
+create index dj_c1c2 on dj (c1 asc, c2 asc);
+
+
+-- =====================================================================
+-- Derived equalities
+-- =====================================================================
+-- de16 is the flagship shape: the bucket is generated from the entity id, so
+-- a lookup by entity id can seek the primary key directly only if the planner
+-- derives the bucket.  Verified on a build with skip scan, WHERE c2 = k still
+-- reaches de16_pkey with the derivation off, but with only c2 as the index
+-- condition, so the pair measures the seek the derivation buys rather than an
+-- index scan against a full scan.  de16_c3c1 is a plain index on a column
+-- with ndv 1000, which is not hot, so it coexists legitimately and gives the
+-- CBO a real rival for OR and multi-predicate queries.
+
+create table de16 (
+  c0 int generated always as (yb_hash_code(c2) % 16) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0 asc, c2 asc, c1 asc)
+) split at values ((1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15));
+
+create index de16_c3c1 on de16 (c3 asc, c1 asc);
+
+-- Redundant derivations, in the spirit of the index in
+-- yugabyte/yugabyte-db#31164 and as synthetic as that one.  c4 leads the key,
+-- so an equality on c4 already seeks as far as the index can, and the three
+-- expression keys after it are functions of c4 alone.  Each therefore gets a
+-- derived equality that narrows nothing, and no path without those binds is
+-- generated for the CBO to compare against.
+create index de16_c4c1 on de16 (c4 asc, (c4 % 20) asc, (c4 + 1) asc, (c4 * 2) asc, c1 asc);
+
+-- Two-column generation expression.  An equality on c2 alone cannot derive
+-- the bucket, only the SAOP over all 8 of them, while equalities on both c2
+-- and c6 derive a single bucket.  The key order puts c2 before c6 so the
+-- partial case still has a usable index condition and the two cases differ
+-- only in stream count.
+
+create table de2c (
+  c0 int generated always as (yb_hash_code(c2, c6) % 8) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0 asc, c2 asc, c6 asc, c1 asc)
+) split at values ((1),(2),(3),(4),(5),(6),(7));
+
+-- Expression index rather than a generated column.  Both derivations have a
+-- separate code path for this form (ybDeriveSaopFromOpExpr reached directly
+-- instead of through the generation expression), so it needs its own table.
+-- The primary key is on the unique entity id, which is not monotone and so
+-- not hot.
+
+create table dex (
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c2 asc)
+) split at values ((75000),(150000),(225000));
+
+-- Two access patterns, each bucketized on the column that spreads its writes,
+-- and neither replaceable by a plain index that would not be hot.
+--
+-- dex_c1c2 answers "the latest events overall": a plain (c1 asc) index would
+-- put every insert on one shard, so the bucket comes first and a query with
+-- no bucket predicate needs a derived SAOP and a merge to get c1 order.
+create index dex_c1c2 on dex ((yb_hash_code(c2) % 8) asc, c1 asc, c2 asc) split at values ((1),(2),(3),(4),(5),(6),(7));
+
+-- dex_c3c1 answers "one entity's events in time order", with c3 as the entity
+-- (ndv 1000, so 300 rows each).  Here the derived equality is the whole
+-- point: without it a lookup by entity cannot pin the bucket and has to visit
+-- all eight, and with it the scan is one seek.
+create index dex_c3c1 on dex ((yb_hash_code(c3) % 8) asc, c3 asc, c1 asc) split at values ((1),(2),(3),(4),(5),(6),(7));
+
+
+-- =====================================================================
+-- Rival index suite
+-- =====================================================================
+-- These two tables exist only to hold the configuration the rest of the
+-- model refuses: a plain index on the very column the bucketized entity
+-- orders by.  A user who bucketizes to escape a hot shard does not keep the
+-- hot index, so this is not what the feature is for, and the coverage is
+-- deliberately thin.  Each is a copy of a table elsewhere in the model with
+-- exactly one index added, so the pairs (sa, riv) and (mb16, rivb) isolate
+-- the rival index as the only variable.
+
+create table riv (
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c2 asc)
+) split at values ((125000),(250000),(375000));
+
+create index riv_c6c1 on riv (c6 asc, c1 asc);
+create index riv_c4c1 on riv (c4 asc, c1 asc);
+create index riv_c3c1 on riv (c3 asc, c1 asc);
+
+-- The rivals.  These two indexes are the only difference between riv and sa.
+-- riv_c1 is the bare ordered index a deployment keeps for "the latest rows",
+-- which answers an ORDER BY c1 with one seek but has to reach the table for
+-- any filter column.  riv_c1c6 covers the c6-filtered listing as well, so the
+-- merge has to beat a rival with no weakness at all.  Both are the hot index
+-- that bucketing exists to remove, and both are here on purpose.
+create index riv_c1 on riv (c1 asc);
+create index riv_c1c6 on riv (c1 asc, c6 asc);
+
+create table rivb (
+  c0 int generated always as (yb_hash_code(c2) % 16) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0 asc, c1 asc, c2 asc)
+) split at values ((1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15));
+
+-- The rival, covering exactly what the bucketized primary key covers for an
+-- ORDER BY c1 query, so neither side pays a table lookup the other avoids and
+-- the comparison is streams against no streams and nothing else.  This is
+-- literally the index the bucketized key replaced.
+create index rivb_c1c2 on rivb (c1 asc, c2 asc);

--- a/sql/cost-validation-bucketized-v2/drop.sql
+++ b/sql/cost-validation-bucketized-v2/drop.sql
@@ -1,0 +1,17 @@
+drop table if exists mb2 cascade;
+drop table if exists mb4 cascade;
+drop table if exists mb16 cascade;
+drop table if exists mb64 cascade;
+drop table if exists mplain cascade;
+drop table if exists mn16 cascade;
+drop table if exists mw16 cascade;
+drop table if exists ms16 cascade;
+drop table if exists sel cascade;
+drop table if exists sa cascade;
+drop table if exists pt cascade;
+drop table if exists dj cascade;
+drop table if exists de16 cascade;
+drop table if exists de2c cascade;
+drop table if exists dex cascade;
+drop table if exists riv cascade;
+drop table if exists rivb cascade;

--- a/sql/cost-validation-bucketized-v2/import.sql
+++ b/sql/cost-validation-bucketized-v2/import.sql
@@ -1,0 +1,327 @@
+-- Data load for cost-validation-bucketized-v2.
+--
+-- Every table uses the same generator, so tables of the same row count hold
+-- identical data.  That is what makes the model's controlled pairs work:
+-- mb2/mb4/mb16/mb64/mplain/rivb/sa/riv all hold the same 500000 rows and
+-- differ only in schema, so any difference in a result is a schema
+-- difference, never a data difference.
+--
+-- Column values, for a table of N rows:
+--   c1 = i, the monotone 1..N "event time"
+--   c2 = a permutation of 1..N, unique, the hash input
+--   c3 = ndv 1000, an independent permutation folded mod 1000
+--   c4 = ndv 100, likewise
+--   c5 = a permutation of 1..N, unique, never indexed
+--   c6 = ndv 10, likewise
+--   c7 = i % 100 + 1, ndv 100
+--   c8 = c7 in every row except i = 1, where it is c7 + 1.  With no extended
+--        statistics the estimator multiplies two independent 1/100
+--        selectivities and predicts about N/10000 rows for any c7 = j AND
+--        c8 = k pair, while the truth is N/100 - 1 rows when j = k, exactly
+--        one row for the single pair (2, 3), and nothing for every other
+--        pair.  Three points of estimate error under one estimate, which is
+--        the axis merge-07 sweeps.
+--   v  = exactly 64 characters (4096 on mw16), left-padded with '-', so
+--        length(v) = 64 matches every row and any other length matches none.
+--
+-- The permutations come from window functions over random() after setseed,
+-- which is reproducible for a given row count.  Each insert reseeds so the
+-- statements are order independent.
+
+
+-- ---------------------------------------------------------------------
+-- Bucket count sweep, plus its control and its rival-suite copy.
+-- Identical data, 500000 rows.
+-- ---------------------------------------------------------------------
+
+select setseed(0.222);
+insert into mb2 (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 500000) i
+    ) s order by 1;
+
+select setseed(0.222);
+insert into mb4 (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 500000) i
+    ) s order by 1;
+
+select setseed(0.222);
+insert into mb16 (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 500000) i
+    ) s order by 1;
+
+select setseed(0.222);
+insert into mb64 (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 500000) i
+    ) s order by 1;
+
+select setseed(0.222);
+insert into mplain (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 500000) i
+    ) s order by 1;
+
+select setseed(0.222);
+insert into rivb (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 500000) i
+    ) s order by 1;
+
+
+-- ---------------------------------------------------------------------
+-- User-written IN list tables, and the rival-suite copy of sa.
+-- Identical data to the sweep, 500000 rows.
+-- ---------------------------------------------------------------------
+
+select setseed(0.222);
+insert into sa (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 500000) i
+    ) s order by 1;
+
+select setseed(0.222);
+insert into riv (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 500000) i
+    ) s order by 1;
+
+
+-- ---------------------------------------------------------------------
+-- Estimate-error table, 500000 rows, identical to the sweep tables.
+-- ---------------------------------------------------------------------
+
+select setseed(0.222);
+insert into sel (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 500000) i
+    ) s order by 1;
+
+
+-- ---------------------------------------------------------------------
+-- Derived equality tables.
+-- ---------------------------------------------------------------------
+
+select setseed(0.222);
+insert into de16 (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 500000) i
+    ) s order by 1;
+
+select setseed(0.222);
+insert into de2c (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 300000) i
+    ) s order by 1;
+
+select setseed(0.222);
+insert into dex (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 300000) i
+    ) s order by 1;
+
+
+-- ---------------------------------------------------------------------
+-- Stream product table, 300000 rows.
+-- ---------------------------------------------------------------------
+
+select setseed(0.222);
+insert into ms16 (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 300000) i
+    ) s order by 1;
+
+
+-- ---------------------------------------------------------------------
+-- Partitioned table, 200000 rows spread evenly over the four partitions.
+-- ---------------------------------------------------------------------
+
+select setseed(0.222);
+insert into pt (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 200000) i
+    ) s order by 1;
+
+
+-- ---------------------------------------------------------------------
+-- The width pair, 50000 rows each, identical apart from the width of v.
+-- ---------------------------------------------------------------------
+
+select setseed(0.222);
+insert into mn16 (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 50000) i
+    ) s order by 1;
+
+select setseed(0.222);
+insert into mw16 (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 4096, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 50000) i
+    ) s order by 1;
+
+
+-- ---------------------------------------------------------------------
+-- Join partner, 20000 rows.  Its c1 covers 1..20000, so joining it to any
+-- other table on c1 matches the first 20000 rows of that table exactly once.
+-- ---------------------------------------------------------------------
+
+select setseed(0.222);
+insert into dj (c1, c2, c3, c4, c5, c6, c7, c8, v)
+  select i, i2, i3 % 1000 + 1, i4 % 100 + 1, i5, i6 % 10 + 1,
+         i % 100 + 1, case when i = 1 then i % 100 + 2 else i % 100 + 1 end,
+         lpad(md5(i::text), 64, '-')
+    from (
+      select i,
+          row_number() over (order by random()) i2,
+          row_number() over (order by random() + 1) i3,
+          row_number() over (order by random() + 2) i4,
+          row_number() over (order by random() + 3) i5,
+          row_number() over (order by random() + 4) i6
+        from generate_series(1, 20000) i
+    ) s order by 1;

--- a/sql/cost-validation-bucketized-v2/model.conf
+++ b/sql/cost-validation-bucketized-v2/model.conf
@@ -1,0 +1,1 @@
+all-index-check = true

--- a/sql/cost-validation-bucketized-v2/postgres.create.sql
+++ b/sql/cost-validation-bucketized-v2/postgres.create.sql
@@ -1,0 +1,222 @@
+-- PostgreSQL variant of the cost-validation-bucketized-v2 schema, used with
+-- --ddl-prefix=postgres or --db=postgres so the same queries can be run
+-- against upstream for comparison.
+--
+-- Two differences from create.sql, both unavoidable.  yb_hash_code does not
+-- exist upstream, so buckets come from mod(c2, B) instead.  c2 is a
+-- permutation of 1..N, so that is uniform and every bucket holds the same
+-- share, but a given row lands in a different bucket than it does on YB.  And
+-- SPLIT AT VALUES has no meaning here, so there is no tablet layout to
+-- control: upstream reads one B-tree per index and has no streams, so it is
+-- the merge-free reference the whole model is measured against rather than a
+-- second implementation of it.
+--
+-- Everything else is kept identical on purpose, including the indexes that
+-- exist only to be a rival and the expression keys that exist only to be
+-- redundantly derived, so a query's row count and selectivity match on both
+-- systems.
+
+
+-- =====================================================================
+-- Bucket count sweep and its control
+-- =====================================================================
+
+create table mb2 (
+  c0 int generated always as (mod(c2, 2)) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0, c1, c2)
+);
+
+create table mb4 (
+  c0 int generated always as (mod(c2, 4)) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0, c1, c2)
+);
+
+create table mb16 (
+  c0 int generated always as (mod(c2, 16)) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0, c1, c2)
+);
+
+create table mb64 (
+  c0 int generated always as (mod(c2, 64)) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0, c1, c2)
+);
+
+create table mplain (
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c1)
+);
+
+
+-- =====================================================================
+-- Row width pair
+-- =====================================================================
+
+create table mn16 (
+  c0 int generated always as (mod(c2, 16)) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0, c1, c2)
+);
+
+create table mw16 (
+  c0 int generated always as (mod(c2, 16)) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(4096),
+  primary key (c0, c1, c2)
+);
+
+
+-- =====================================================================
+-- Stream product
+-- =====================================================================
+
+create table ms16 (
+  c0 int generated always as (mod(c2, 16)) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0, c6, c1)
+);
+
+
+-- =====================================================================
+-- User-written IN lists, no bucketization
+-- =====================================================================
+
+create table sa (
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c2)
+);
+
+create index sa_c6c1 on sa (c6 asc, c1 asc);
+create index sa_c4c1 on sa (c4 asc, c1 asc);
+create index sa_c3c1 on sa (c3 asc, c1 asc);
+
+
+-- =====================================================================
+-- Estimate error against a selective rival path
+-- =====================================================================
+
+create table sel (
+  c0 int generated always as (mod(c2, 16)) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0, c1, c2)
+);
+
+create index sel_c3c1 on sel (c3 asc, c1 asc);
+create index sel_c7c1 on sel (c7 asc, c1 asc);
+create index sel_vc1 on sel (v asc, c1 asc);
+
+
+-- =====================================================================
+-- Partitioning
+-- =====================================================================
+
+create table pt (
+  c0 int generated always as (mod(c2, 8)) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0, c1, c2)
+) partition by range (c1);
+
+create table pt_p1 partition of pt for values from (1) to (50001);
+create table pt_p2 partition of pt for values from (50001) to (100001);
+create table pt_p3 partition of pt for values from (100001) to (150001);
+create table pt_p4 partition of pt for values from (150001) to (200001);
+
+
+-- =====================================================================
+-- Join partner
+-- =====================================================================
+
+create table dj (
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c2)
+);
+
+create index dj_c1c2 on dj (c1 asc, c2 asc);
+
+
+-- =====================================================================
+-- Derived equalities
+-- =====================================================================
+
+create table de16 (
+  c0 int generated always as (mod(c2, 16)) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0, c2, c1)
+);
+
+create index de16_c3c1 on de16 (c3 asc, c1 asc);
+create index de16_c4c1 on de16 (c4 asc, (c4 % 20), (c4 + 1), (c4 * 2), c1 asc);
+
+create table de2c (
+  c0 int generated always as (mod(c2 + c6, 8)) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0, c2, c6, c1)
+);
+
+create table dex (
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c2)
+);
+
+create index dex_c1c2 on dex ((mod(c2, 8)), c1 asc, c2 asc);
+create index dex_c3c1 on dex ((mod(c3, 8)), c3 asc, c1 asc);
+
+
+-- =====================================================================
+-- Rival index suite
+-- =====================================================================
+
+create table riv (
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c2)
+);
+
+create index riv_c6c1 on riv (c6 asc, c1 asc);
+create index riv_c4c1 on riv (c4 asc, c1 asc);
+create index riv_c3c1 on riv (c3 asc, c1 asc);
+create index riv_c1 on riv (c1 asc);
+create index riv_c1c6 on riv (c1 asc, c6 asc);
+
+create table rivb (
+  c0 int generated always as (mod(c2, 16)) stored,
+  c1 int not null, c2 int not null,
+  c3 int, c4 int, c5 int, c6 int, c7 int, c8 int,
+  v char(64),
+  primary key (c0, c1, c2)
+);
+
+create index rivb_c1c2 on rivb (c1 asc, c2 asc);

--- a/sql/cost-validation-bucketized-v2/queries/eq-01-point-and-range.sql
+++ b/sql/cost-validation-bucketized-v2/queries/eq-01-point-and-range.sql
@@ -1,0 +1,120 @@
+-- yb_enable_derived_equalities: single-table lookups.
+--
+-- When an index key is a generated column or an index expression, and the
+-- query pins every column that expression reads, the planner can compute the
+-- key's value and add it as an index condition.  That is what makes a
+-- bucketized index usable for a lookup that never mentions the bucket: the
+-- user asks for entity 123456 and the planner supplies bucket
+-- yb_hash_code(123456) % 16 on their behalf.  Without it the lookup has to
+-- visit every bucket, and the whole point of putting the bucket first in the
+-- key is lost.
+--
+-- Two open defects show up in the plans this file produces.  The derived
+-- expression is never const-folded, so the index condition reads
+-- "c0 = (yb_hash_code(123456) % 16)" rather than "c0 = 2" and the executor
+-- treats it as a runtime key (yugabyte/yugabyte-db#31354).  And no path
+-- without the derivation is generated, so where the derivation is not worth
+-- its binds the CBO is not offered the alternative (#31164), which is what
+-- eq-04 is about.
+--
+-- Three tables, three forms of the derivation.  de16 generates its bucket
+-- from one column, de2c from two, so an equality on one of them is not
+-- enough, and dex has no generated column at all and derives on the index
+-- expression itself.  Where a bucket cannot be derived a derived SAOP over
+-- all the buckets usually can be, so most of the pairs below are one seek
+-- against a merge over every bucket rather than against a full scan.
+--
+-- Data facts: de16 has 500000 rows with c2 unique, de2c has 300000 with c2
+-- unique and c6 of ndv 10, dex has 300000 with c3 of ndv 1000, so about 300
+-- rows per c3 value.
+
+
+-- ---------------------------------------------------------------------
+-- The flagship: a lookup by the column the bucket is generated from.  All
+-- of the bucket has to be derived, or all of it visited.
+-- ---------------------------------------------------------------------
+SELECT c1, c3, c4 FROM de16 WHERE c2 = 123456;
+SELECT c1, c3, c4 FROM de16 WHERE c2 = 1;
+SELECT c1, c3, c4 FROM de16 WHERE c2 = 499999;
+SELECT c1 FROM de16 WHERE c2 = 123456;
+SELECT * FROM de16 WHERE c2 = 123456;
+SELECT count(*) FROM de16 WHERE c2 = 123456;
+
+
+-- ---------------------------------------------------------------------
+-- Several values at once.  An IN list is not an equality, so no bucket can
+-- be derived from it and the index has to be reached another way.  These
+-- are the boundary of what the derivation covers.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM de16 WHERE c2 IN (1, 123456);
+SELECT c1, c3 FROM de16 WHERE c2 IN (1, 2, 3, 4, 5, 6, 7, 8);
+SELECT c1, c3 FROM de16 WHERE c2 BETWEEN 1 AND 8;
+SELECT c1, c3 FROM de16 WHERE c2 BETWEEN 1 AND 5000;
+SELECT count(*) FROM de16 WHERE c2 BETWEEN 1 AND 5000;
+
+
+-- ---------------------------------------------------------------------
+-- The equality plus a range on the next key column, so the derived bucket
+-- and the user's conditions form a full key prefix.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM de16 WHERE c2 = 123456 AND c1 > 0;
+SELECT c1, c3 FROM de16 WHERE c2 = 123456 AND c1 BETWEEN 1 AND 500000;
+SELECT c1, c3 FROM de16 WHERE c2 = 123456 ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM de16 WHERE c2 = 123456 AND c4 = 50;
+SELECT c1, c3 FROM de16 WHERE c2 = 123456 AND sign(c1 - c2) = 1;
+
+
+-- ---------------------------------------------------------------------
+-- The equality reached through an equivalence class rather than written
+-- against a constant.  The planner substitutes whatever the class knows, so
+-- these should derive exactly as the direct forms do.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM de16 WHERE c2 = 123456 AND c2 = c2;
+SELECT c1, c3 FROM de16 WHERE 123456 = c2;
+SELECT c1, c3 FROM de16 WHERE c2 = 123455 + 1;
+
+
+-- ---------------------------------------------------------------------
+-- Two columns feeding one bucket.  An equality on c2 alone cannot compute
+-- the key, but an equality on c2 and c6 together can, so the pair shows the
+-- derivation's cost when it fires against when it cannot.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM de2c WHERE c2 = 12345;
+SELECT c1, c3 FROM de2c WHERE c2 = 12345 AND c6 = 3;
+SELECT c1, c3 FROM de2c WHERE c6 = 3 AND c2 = 12345;
+SELECT c1, c3 FROM de2c WHERE c2 = 12345 AND c6 IN (1,2,3);
+SELECT c1, c3 FROM de2c WHERE c2 = 12345 AND c6 BETWEEN 1 AND 3;
+SELECT c1, c3 FROM de2c WHERE c6 = 3;
+SELECT count(*) FROM de2c WHERE c2 = 12345;
+SELECT count(*) FROM de2c WHERE c2 = 12345 AND c6 = 3;
+
+
+-- ---------------------------------------------------------------------
+-- The same on an index expression with no generated column behind it.
+-- dex_c3c1 is (bucket of c3, c3, c1), so an equality on c3 both derives the
+-- bucket and supplies the second key, leaving c1 ordered.  This is the
+-- "one entity's events in time order" access pattern the index exists for,
+-- and it is where the derivation is worth the most.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM dex WHERE c3 = 500 ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM dex WHERE c3 = 500 ORDER BY c1 LIMIT 100;
+SELECT c1, c3 FROM dex WHERE c3 = 500 ORDER BY c1;
+SELECT c1, c3 FROM dex WHERE c3 = 500 ORDER BY c1 DESC LIMIT 10;
+SELECT c1, c3 FROM dex WHERE c3 = 500;
+SELECT count(*) FROM dex WHERE c3 = 500;
+SELECT c1, c3 FROM dex WHERE c3 = 500 AND c1 > 150000 ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM dex WHERE c3 IN (500, 501) ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM dex WHERE c3 IN (500, 501, 502, 503) ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM dex WHERE c3 BETWEEN 500 AND 503 ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- Lookups that return nothing.  The derived bucket is computed from a value
+-- no row carries, so the seek lands in the right bucket and finds nothing,
+-- which is the cheapest possible correct answer and worth checking is what
+-- the model predicts.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM de16 WHERE c2 = 900001;
+SELECT c1, c3 FROM de2c WHERE c2 = 900001 AND c6 = 3;
+SELECT c1, c3 FROM dex WHERE c3 = 1001 ORDER BY c1 LIMIT 10;
+SELECT count(*) FROM de16 WHERE c2 = 900001;

--- a/sql/cost-validation-bucketized-v2/queries/eq-02-joins.sql
+++ b/sql/cost-validation-bucketized-v2/queries/eq-02-joins.sql
@@ -1,0 +1,109 @@
+-- yb_enable_derived_equalities: joins.
+--
+-- This is where the derivation is worth the most and where it is most
+-- dangerous.  On the inner side of a nested loop the outer row supplies the
+-- entity id, and the planner substitutes it into the generation expression to
+-- produce a bucket condition per probe, so the inner scan is one seek rather
+-- than a visit to every bucket.  Without it a bucketized table is close to
+-- unusable as an inner side, which means the derivation is not an
+-- optimization here so much as the thing that makes the schema work.
+--
+-- The danger is on the other side of the same coin.  A path that only exists
+-- because of a derived condition is a path the planner did not have before,
+-- and it can win the join order on an estimate rather than on merit, which is
+-- the mechanism saop-03 covers for derived SAOPs.  The derived condition is
+-- also a runtime key rather than a constant (yugabyte/yugabyte-db#31354), so
+-- it is re-evaluated on every rescan, which a per-probe cost should account
+-- for and today does not.
+--
+-- dj holds 20000 rows with c1 = 1..20000 and c2 a permutation of the same
+-- range, so every join here matches 20000 rows exactly once.  mplain and sa
+-- appear as the sides where no derivation is possible.
+--
+-- Aliases are used throughout, as the framework requires for join queries.
+
+
+-- ---------------------------------------------------------------------
+-- The bucketized table as inner, probed on the column its bucket is
+-- generated from.  Each probe can be a single seek only if the bucket is
+-- derived from the outer row's value.
+-- ---------------------------------------------------------------------
+SELECT d.c2, m.c1 FROM dj d JOIN de16 m ON m.c2 = d.c2 WHERE d.c4 = 1;
+SELECT d.c2, m.c1 FROM dj d JOIN de16 m ON m.c2 = d.c2 WHERE d.c4 IN (1,2,3,4);
+SELECT d.c2, m.c1 FROM dj d JOIN de16 m ON m.c2 = d.c2;
+SELECT count(*) FROM dj d JOIN de16 m ON m.c2 = d.c2;
+SELECT d.c2, m.c1, m.c3 FROM dj d JOIN de16 m ON m.c2 = d.c2 WHERE d.c4 = 1 ORDER BY d.c2 LIMIT 100;
+SELECT d.c2, m.c1 FROM dj d JOIN mplain m ON m.c2 = d.c2 WHERE d.c4 = 1;
+SELECT count(*) FROM dj d JOIN mplain m ON m.c2 = d.c2;
+
+
+-- ---------------------------------------------------------------------
+-- Both generation columns supplied by the join, so the two-column bucket
+-- can be derived, against only one of them supplied, where it cannot.
+-- ---------------------------------------------------------------------
+SELECT d.c2, m.c1 FROM dj d JOIN de2c m ON m.c2 = d.c2 AND m.c6 = d.c6 WHERE d.c4 = 1;
+SELECT d.c2, m.c1 FROM dj d JOIN de2c m ON m.c2 = d.c2 WHERE d.c4 = 1;
+SELECT count(*) FROM dj d JOIN de2c m ON m.c2 = d.c2 AND m.c6 = d.c6;
+SELECT count(*) FROM dj d JOIN de2c m ON m.c2 = d.c2;
+SELECT d.c2, m.c1, m.c3 FROM dj d JOIN de2c m ON m.c2 = d.c2 AND m.c6 = d.c6 ORDER BY d.c2 LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- The expression index as inner, probed on the entity column.  Here the
+-- derivation pins the bucket and the index still supplies c1 order inside
+-- it, so the inner side is both seekable and ordered.
+-- ---------------------------------------------------------------------
+SELECT d.c3, x.c1 FROM dj d JOIN dex x ON x.c3 = d.c3 WHERE d.c4 = 1;
+SELECT d.c3, x.c1 FROM dj d JOIN dex x ON x.c3 = d.c3 WHERE d.c4 = 1 ORDER BY d.c3, x.c1 LIMIT 100;
+SELECT count(*) FROM dj d JOIN dex x ON x.c3 = d.c3;
+SELECT d.c3, count(*) FROM dj d JOIN dex x ON x.c3 = d.c3 GROUP BY d.c3 ORDER BY d.c3 LIMIT 100;
+SELECT d.c3, x.c1 FROM dj d JOIN sa x ON x.c3 = d.c3 WHERE d.c4 = 1;
+
+
+-- ---------------------------------------------------------------------
+-- The bucketized side as outer, so the derivation has nothing to do and
+-- the plans should match the ones with the GUC off.  These bracket the
+-- blocks above.
+-- ---------------------------------------------------------------------
+SELECT m.c2, d.c1 FROM de16 m JOIN dj d ON d.c2 = m.c2 WHERE m.c4 = 1;
+SELECT m.c2, d.c1 FROM de16 m JOIN dj d ON d.c2 = m.c2 ORDER BY m.c2 LIMIT 100;
+SELECT m.c2, d.c1 FROM de2c m JOIN dj d ON d.c2 = m.c2 AND d.c6 = m.c6 WHERE m.c4 = 1;
+
+
+-- ---------------------------------------------------------------------
+-- Semi and anti joins, which reach the inner side through a different path
+-- in the planner and derive separately.
+-- ---------------------------------------------------------------------
+SELECT d.c2 FROM dj d WHERE EXISTS (SELECT 1 FROM de16 m WHERE m.c2 = d.c2 AND m.c4 = 1);
+SELECT d.c2 FROM dj d WHERE NOT EXISTS (SELECT 1 FROM de16 m WHERE m.c2 = d.c2 AND m.c4 = 1);
+SELECT d.c2 FROM dj d WHERE EXISTS (SELECT 1 FROM de2c m WHERE m.c2 = d.c2 AND m.c6 = d.c6);
+SELECT d.c3 FROM dj d WHERE EXISTS (SELECT 1 FROM dex x WHERE x.c3 = d.c3 AND x.c4 = 1);
+SELECT d.c2 FROM dj d WHERE EXISTS (SELECT 1 FROM mplain m WHERE m.c2 = d.c2 AND m.c4 = 1);
+SELECT count(*) FROM dj d WHERE d.c2 IN (SELECT m.c2 FROM de16 m WHERE m.c4 = 1);
+
+
+-- ---------------------------------------------------------------------
+-- Outer joins, where the inner side is probed for every outer row whether
+-- it matches or not, so a per-probe cost error is paid in full.
+-- ---------------------------------------------------------------------
+SELECT d.c2, m.c1 FROM dj d LEFT JOIN de16 m ON m.c2 = d.c2 AND m.c4 = 1;
+SELECT d.c2, m.c1 FROM dj d LEFT JOIN de2c m ON m.c2 = d.c2 AND m.c6 = d.c6;
+SELECT d.c3, x.c1 FROM dj d LEFT JOIN dex x ON x.c3 = d.c3 AND x.c4 = 1;
+SELECT count(*) FROM dj d LEFT JOIN de16 m ON m.c2 = d.c2;
+
+
+-- ---------------------------------------------------------------------
+-- Aggregation above the join, so no LIMIT reaches either side and the
+-- comparison is on total work rather than on early termination.
+-- ---------------------------------------------------------------------
+SELECT d.c4, count(*), avg(m.c3) FROM dj d JOIN de16 m ON m.c2 = d.c2 GROUP BY d.c4 ORDER BY d.c4;
+SELECT d.c4, count(*), avg(m.c3) FROM dj d JOIN mplain m ON m.c2 = d.c2 GROUP BY d.c4 ORDER BY d.c4;
+SELECT d.c4, count(*) FROM dj d JOIN dex x ON x.c3 = d.c3 GROUP BY d.c4 ORDER BY d.c4;
+
+
+-- ---------------------------------------------------------------------
+-- Three tables, so the derivation has more than one join order to change.
+-- ---------------------------------------------------------------------
+SELECT d.c2, m.c1, x.c1 FROM dj d JOIN de16 m ON m.c2 = d.c2 JOIN dex x ON x.c3 = d.c3 WHERE d.c4 = 1;
+SELECT count(*) FROM dj d JOIN de16 m ON m.c2 = d.c2 JOIN de2c e ON e.c2 = d.c2 AND e.c6 = d.c6;
+SELECT d.c2, m.c1 FROM dj d JOIN de16 m ON m.c2 = d.c2 JOIN mplain p ON p.c1 = d.c1 WHERE d.c4 = 1 ORDER BY d.c2 LIMIT 100;

--- a/sql/cost-validation-bucketized-v2/queries/eq-03-or-and-bitmap.sql
+++ b/sql/cost-validation-bucketized-v2/queries/eq-03-or-and-bitmap.sql
@@ -1,0 +1,108 @@
+-- yb_enable_derived_equalities: OR conditions and bitmap scans.
+--
+-- Individual arms of an OR do not form equivalence classes, so the derivation
+-- for them runs through a separate path in the planner that reads the arms'
+-- Var = Const bindings directly.  That makes an OR the one place where the
+-- derivation can fire for one branch and not another, and where each branch
+-- gets its own index condition, so it is worth its own file.
+--
+-- It is also where yugabyte/yugabyte-db#31354 is visible.  The derivation
+-- substitutes the constant into the generation expression but never runs the
+-- result through const folding, because const folding happens during query
+-- preprocessing and the derivation happens later, during path generation.  So
+-- the plan carries "c0 = (yb_hash_code(123456) % 16)" rather than "c0 = 2".
+-- The executor classifies a non-Const right hand side as a runtime key, and
+-- for a bitmap index scan any runtime key sets the might-recheck flag, which
+-- puts a Recheck Cond and a Storage Recheck Cond in the plan that a folded
+-- constant would not.  Verified on this schema: the OR queries below produce
+-- exactly that, with the unfolded expression in both the Bitmap Index Scan's
+-- Index Cond and the Bitmap Table Scan's Recheck Cond.
+--
+-- de16 has the bucketized primary key on (c0, c2, c1) and a plain index on
+-- (c3, c1), so a two-armed OR can put one arm on each and the BitmapOr has
+-- something real to combine.  de2c and dex give the two-column and
+-- expression-index forms of the same thing.
+
+
+-- ---------------------------------------------------------------------
+-- One arm on the derived bucket, one arm on a plain index.  This is the
+-- BitmapOr shape, and it is where the unfolded runtime key appears.
+-- ---------------------------------------------------------------------
+SELECT c1, c2, c3 FROM de16 WHERE c2 = 123456 OR c3 = 500;
+SELECT c1, c2, c3 FROM de16 WHERE c2 = 123456 OR c3 = 1;
+SELECT c1, c2, c3 FROM de16 WHERE c2 = 1 OR c2 = 123456;
+SELECT c1, c2, c3 FROM de16 WHERE c2 = 1 OR c2 = 2 OR c2 = 3;
+SELECT count(*) FROM de16 WHERE c2 = 123456 OR c3 = 500;
+SELECT c1, c2, c3 FROM de16 WHERE c2 = 123456 OR c3 = 500 ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- Arms of unequal weight, so the planner has to decide whether combining
+-- them beats scanning for the cheaper one and filtering.
+-- ---------------------------------------------------------------------
+SELECT c1, c2, c3 FROM de16 WHERE c2 = 123456 OR c3 BETWEEN 1 AND 50;
+SELECT c1, c2, c3 FROM de16 WHERE c2 = 123456 OR c4 = 50;
+SELECT c1, c2, c3 FROM de16 WHERE c2 = 123456 OR c5 = 250000;
+SELECT c1, c2, c3 FROM de16 WHERE c3 = 500 OR c3 = 501;
+SELECT count(*) FROM de16 WHERE c2 = 123456 OR c4 = 50;
+
+
+-- ---------------------------------------------------------------------
+-- An OR where one arm can be derived and the other cannot, because it uses
+-- a range rather than an equality.  Only half of this query benefits.
+-- ---------------------------------------------------------------------
+SELECT c1, c2, c3 FROM de16 WHERE c2 = 123456 OR c2 BETWEEN 1 AND 100;
+SELECT c1, c2, c3 FROM de16 WHERE c2 BETWEEN 1 AND 100 OR c3 = 500;
+SELECT c1, c2, c3 FROM de16 WHERE c2 IN (1, 2, 3) OR c3 = 500;
+
+
+-- ---------------------------------------------------------------------
+-- Conjunctions of arms, which give a BitmapAnd rather than a BitmapOr and
+-- reach the derivation from the other side.
+-- ---------------------------------------------------------------------
+SELECT c1, c2, c3 FROM de16 WHERE c3 = 500 AND c4 = 50;
+SELECT c1, c2, c3 FROM de16 WHERE (c2 = 123456 OR c3 = 500) AND c4 = 50;
+SELECT c1, c2, c3 FROM de16 WHERE (c2 = 123456 OR c3 = 500) AND (c4 = 50 OR c6 = 1);
+SELECT count(*) FROM de16 WHERE (c2 = 123456 OR c3 = 500) AND c4 = 50;
+
+
+-- ---------------------------------------------------------------------
+-- The two-column generation expression under an OR.  An arm that pins only
+-- c2 cannot derive the bucket, and an arm that pins c2 and c6 can, so the
+-- two arms of one query take different paths.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM de2c WHERE (c2 = 12345 AND c6 = 3) OR (c2 = 54321 AND c6 = 5);
+SELECT c1, c2 FROM de2c WHERE (c2 = 12345 AND c6 = 3) OR c2 = 54321;
+SELECT c1, c2 FROM de2c WHERE c2 = 12345 OR c2 = 54321;
+SELECT count(*) FROM de2c WHERE (c2 = 12345 AND c6 = 3) OR (c2 = 54321 AND c6 = 5);
+
+
+-- ---------------------------------------------------------------------
+-- The expression index under an OR, where the derived condition is on the
+-- index expression itself rather than on a stored column.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM dex WHERE c3 = 500 OR c3 = 501;
+SELECT c1, c3 FROM dex WHERE c3 = 500 OR c4 = 50;
+SELECT c1, c3 FROM dex WHERE c3 = 500 OR c2 = 12345;
+SELECT count(*) FROM dex WHERE c3 = 500 OR c3 = 501;
+SELECT c1, c3 FROM dex WHERE c3 = 500 OR c3 = 501 ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- The same queries against tables where nothing can be derived, so the
+-- bitmap plans are the plain form of each shape.  sa and mplain hold the
+-- same rows as de16.
+-- ---------------------------------------------------------------------
+SELECT c1, c2, c3 FROM sa WHERE c2 = 123456 OR c3 = 500;
+SELECT c1, c2, c3 FROM sa WHERE c3 = 500 OR c4 = 50;
+SELECT c1, c2, c3 FROM mplain WHERE c1 = 123456 OR c3 = 500;
+SELECT count(*) FROM sa WHERE c2 = 123456 OR c3 = 500;
+
+
+-- ---------------------------------------------------------------------
+-- Rescan, where the unfolded expression is re-evaluated for every outer
+-- row rather than being a constant fixed in the plan.
+-- ---------------------------------------------------------------------
+SELECT d.c2, m.c1 FROM dj d JOIN de16 m ON m.c2 = d.c2 WHERE m.c3 = 500 OR m.c4 = 50;
+SELECT d.c3, x.c1 FROM dj d JOIN dex x ON x.c3 = d.c3 WHERE x.c4 = 50 OR x.c6 = 1;
+SELECT count(*) FROM dj d JOIN de16 m ON m.c2 = d.c2 WHERE m.c3 = 500 OR m.c4 = 50;

--- a/sql/cost-validation-bucketized-v2/queries/eq-04-derivation-overhead.sql
+++ b/sql/cost-validation-bucketized-v2/queries/eq-04-derivation-overhead.sql
@@ -1,0 +1,115 @@
+-- yb_enable_derived_equalities: derivations that cost more than they save.
+--
+-- Two overheads, both from yugabyte/yugabyte-db#31164, and both invisible to
+-- the CBO because no path without the derived conditions is generated.  The
+-- planner cannot choose not to derive, so a comparison has to come from two
+-- runs with the GUC set differently.
+--
+-- The first overhead is redundant binds.  de16_c4c1 is (c4, c4 % 20, c4 + 1,
+-- c4 * 2, c1), so an equality on c4 already seeks as far as that index can
+-- go, and the three expression keys after it are functions of c4 alone.  Each
+-- gets a derived equality anyway.  Verified on this schema, WHERE c4 = 50
+-- produces
+--
+--   Index Cond: ((c4 = 50) AND (((c4 % 20)) = (50 % 20))
+--                AND (((c4 + 1)) = (50 + 1)) AND (((c4 * 2)) = (50 * 2)))
+--
+-- against Index Cond: (c4 = 50) with the GUC off.  Three extra conditions on
+-- the wire per bind, none of which removes a row, and none of them folded to
+-- a constant either (#31354), so all three are runtime keys.
+--
+-- The second overhead is streams that cannot exist.  On dex_c3c1 an equality
+-- on c3 derives the bucket exactly, which should leave one stream, but the
+-- derived SAOP over all eight buckets is planned as well, so the plan says
+-- Merge Streams: 8 while bind-time pruning leaves one read op.  The planner
+-- is costing eight streams for work the executor never does, which is the
+-- mirror image of the usual complaint that it undercharges for streams.
+--
+-- The index in the first half is as synthetic as the one in the issue, and
+-- says so.  The point is not that anyone writes that index, it is that the
+-- derivation fires on every expression key it can regardless of whether the
+-- key was already pinned.
+
+
+-- ---------------------------------------------------------------------
+-- Redundant binds.  Every query here derives three conditions that narrow
+-- nothing, and the row counts vary so the per-bind cost can be separated
+-- from the per-row cost.
+-- ---------------------------------------------------------------------
+SELECT c1, c4 FROM de16 WHERE c4 = 50 ORDER BY c1 LIMIT 10;
+SELECT c1, c4 FROM de16 WHERE c4 = 50 ORDER BY c1 LIMIT 1000;
+SELECT c1, c4 FROM de16 WHERE c4 = 50 ORDER BY c1;
+SELECT c1, c4 FROM de16 WHERE c4 = 50;
+SELECT count(*) FROM de16 WHERE c4 = 50;
+SELECT c1, c4 FROM de16 WHERE c4 = 50 AND c1 > 250000 ORDER BY c1 LIMIT 10;
+SELECT c1, c4 FROM de16 WHERE c4 = 1 ORDER BY c1 LIMIT 10;
+SELECT c1, c4 FROM de16 WHERE c4 = 100 ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- The same index reached without an equality, so nothing is derived.  A
+-- range or an IN list on c4 gives no constant to substitute, which makes
+-- these the within-table control for the block above.
+-- ---------------------------------------------------------------------
+SELECT c1, c4 FROM de16 WHERE c4 BETWEEN 50 AND 50 ORDER BY c1 LIMIT 10;
+SELECT c1, c4 FROM de16 WHERE c4 IN (50) ORDER BY c1 LIMIT 10;
+SELECT c1, c4 FROM de16 WHERE c4 IN (50, 51) ORDER BY c1 LIMIT 10;
+SELECT c1, c4 FROM de16 WHERE c4 BETWEEN 50 AND 55 ORDER BY c1 LIMIT 10;
+SELECT count(*) FROM de16 WHERE c4 BETWEEN 50 AND 50;
+
+
+-- ---------------------------------------------------------------------
+-- The same shape on a table with no expression keys at all, holding the
+-- same rows.  sa_c4c1 is (c4, c1) and nothing can be derived on it, so the
+-- pair with the first block is the cost of the redundant binds.
+-- ---------------------------------------------------------------------
+SELECT c1, c4 FROM sa WHERE c4 = 50 ORDER BY c1 LIMIT 10;
+SELECT c1, c4 FROM sa WHERE c4 = 50 ORDER BY c1 LIMIT 1000;
+SELECT c1, c4 FROM sa WHERE c4 = 50 ORDER BY c1;
+SELECT count(*) FROM sa WHERE c4 = 50;
+SELECT c1, c4 FROM sa WHERE c4 = 50 AND c1 > 250000 ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- Redundant binds inside a join, where they are re-evaluated per probe
+-- rather than once, so a per-bind cost is multiplied by the outer rows.
+-- ---------------------------------------------------------------------
+SELECT d.c4, m.c1 FROM dj d JOIN de16 m ON m.c4 = d.c4 WHERE d.c3 = 500;
+SELECT d.c4, m.c1 FROM dj d JOIN sa m ON m.c4 = d.c4 WHERE d.c3 = 500;
+SELECT count(*) FROM dj d JOIN de16 m ON m.c4 = d.c4 WHERE d.c3 BETWEEN 1 AND 10;
+SELECT count(*) FROM dj d JOIN sa m ON m.c4 = d.c4 WHERE d.c3 BETWEEN 1 AND 10;
+
+
+-- ---------------------------------------------------------------------
+-- Streams planned that cannot exist.  The equality on c3 pins one bucket,
+-- yet the derived SAOP over all eight is planned alongside it, so the cost
+-- covers eight streams and the executor prunes seven at bind time.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM dex WHERE c3 = 500 ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM dex WHERE c3 = 500 ORDER BY c1 LIMIT 100;
+SELECT c1, c3 FROM dex WHERE c3 = 500 ORDER BY c1;
+SELECT c1, c3 FROM dex WHERE c3 = 500 AND c1 > 150000 ORDER BY c1 LIMIT 10;
+SELECT count(*) FROM dex WHERE c3 = 500;
+SELECT c1, c3 FROM dex WHERE c3 = 500 ORDER BY c1 DESC LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- The same lookup where every bucket really does have to be visited,
+-- because no equality pins one.  This is what eight streams should cost,
+-- and the block above should not be paying it.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM dex WHERE c3 IN (500, 501) ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM dex ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM dex ORDER BY c1 LIMIT 100;
+SELECT c1, c3 FROM sa WHERE c3 = 500 ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 = 500 ORDER BY c1;
+
+
+-- ---------------------------------------------------------------------
+-- Wide projections, so any per-bind overhead is measured against a larger
+-- per-row cost and the two can be told apart.
+-- ---------------------------------------------------------------------
+SELECT * FROM de16 WHERE c4 = 50 ORDER BY c1 LIMIT 10;
+SELECT * FROM sa WHERE c4 = 50 ORDER BY c1 LIMIT 10;
+SELECT * FROM de16 WHERE c4 = 50 ORDER BY c1 LIMIT 1000;
+SELECT * FROM sa WHERE c4 = 50 ORDER BY c1 LIMIT 1000;

--- a/sql/cost-validation-bucketized-v2/queries/merge-01-bucket-sweep.sql
+++ b/sql/cost-validation-bucketized-v2/queries/merge-01-bucket-sweep.sql
@@ -1,0 +1,128 @@
+-- Merge scan: bucket count sweep.
+--
+-- mb2, mb4, mb16 and mb64 hold identical rows and differ only in the number
+-- of buckets, and mplain holds the same rows with a plain ordered primary key
+-- and no streams at all.  Each query shape below is repeated across all five,
+-- so within a shape the stream count is the only thing that changes.
+--
+-- What this is for: today the cost model's only merge-specific behavior is
+-- multiplying the plain scan cost by 1.02 (yugabyte/yugabyte-db#29078), so it
+-- charges the same for 2 streams as for 64.  The executor does not.  Every
+-- stream is handed the full LIMIT and the merge cannot emit a row until all
+-- of them have returned their first page, so both the fetch work and the time
+-- to first row grow with the bucket count.  A cost model that has learned to
+-- see stream count should produce a cost that rises across mb2, mb4, mb16 and
+-- mb64 within each shape, and the mplain row is the floor those costs are
+-- rising above.
+--
+-- These tables carry no index besides the bucketized primary key, so the only
+-- alternative to merge scan is a sort over a full scan.  That is deliberate:
+-- a plain (c1 asc) index would be the hot shard the bucketing exists to
+-- avoid, and its presence would make the comparison meaningless.  The rival
+-- suite covers the case where such an index exists anyway.
+
+
+-- ---------------------------------------------------------------------
+-- LIMIT 1: the pure startup cost of the merge.  Every stream still fetches
+-- a page even though one row is wanted, and nothing is emitted until the
+-- last of them answers.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb2 ORDER BY c1 LIMIT 1;
+SELECT c1, c2 FROM mb4 ORDER BY c1 LIMIT 1;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 1;
+SELECT c1, c2 FROM mb64 ORDER BY c1 LIMIT 1;
+SELECT c1, c2 FROM mplain ORDER BY c1 LIMIT 1;
+
+
+-- ---------------------------------------------------------------------
+-- LIMIT 10, still far below the 1024-row fetch page, so the work per stream
+-- is unchanged from LIMIT 1 and only the returned row count differs.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb2 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb4 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb64 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mplain ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- LIMIT 1000: the first round fetches min(LIMIT, fetch page) rows per
+-- stream, so mb64 reads about 64000 rows to return 1000 while mplain reads
+-- about 1000.  This is where the per-stream fetch term should show up most
+-- clearly in a corrected model.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb2 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mb4 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mb64 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mplain ORDER BY c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- LIMIT 1100, just past the default yb_fetch_row_limit of 1024, so a second
+-- fetch round is required.  Compare against the LIMIT 1000 row above: the
+-- cost should step here and be flat below.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb2 ORDER BY c1 LIMIT 1100;
+SELECT c1, c2 FROM mb4 ORDER BY c1 LIMIT 1100;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 1100;
+SELECT c1, c2 FROM mb64 ORDER BY c1 LIMIT 1100;
+SELECT c1, c2 FROM mplain ORDER BY c1 LIMIT 1100;
+
+
+-- ---------------------------------------------------------------------
+-- Full drain with a small result: OFFSET forces every row through the
+-- ordered path while only ten come back, so the row count returned does not
+-- confound the measurement.  No early termination discount is earned here.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb2 ORDER BY c1 OFFSET 499990 LIMIT 10;
+SELECT c1, c2 FROM mb4 ORDER BY c1 OFFSET 499990 LIMIT 10;
+SELECT c1, c2 FROM mb16 ORDER BY c1 OFFSET 499990 LIMIT 10;
+SELECT c1, c2 FROM mb64 ORDER BY c1 OFFSET 499990 LIMIT 10;
+SELECT c1, c2 FROM mplain ORDER BY c1 OFFSET 499990 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- Descending order.  The bucketized keys are all ascending, so this is the
+-- backward merge, which pages the same way forward does.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb2 ORDER BY c1 DESC LIMIT 100;
+SELECT c1, c2 FROM mb4 ORDER BY c1 DESC LIMIT 100;
+SELECT c1, c2 FROM mb16 ORDER BY c1 DESC LIMIT 100;
+SELECT c1, c2 FROM mb64 ORDER BY c1 DESC LIMIT 100;
+SELECT c1, c2 FROM mplain ORDER BY c1 DESC LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- Wide projection.  Selecting v takes the query off the covering path and
+-- makes each fetched row about 64 bytes larger, which multiplies by the
+-- stream count in the first fetch round.
+-- ---------------------------------------------------------------------
+SELECT * FROM mb2 ORDER BY c1 LIMIT 100;
+SELECT * FROM mb4 ORDER BY c1 LIMIT 100;
+SELECT * FROM mb16 ORDER BY c1 LIMIT 100;
+SELECT * FROM mb64 ORDER BY c1 LIMIT 100;
+SELECT * FROM mplain ORDER BY c1 LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- A selective filter that the storage layer evaluates.  Roughly one row in
+-- a hundred qualifies, so ten thousand rows must be read to satisfy the
+-- LIMIT, and each stream reads its own share of them.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb2 WHERE c4 = 50 ORDER BY c1 LIMIT 100;
+SELECT c1, c2 FROM mb4 WHERE c4 = 50 ORDER BY c1 LIMIT 100;
+SELECT c1, c2 FROM mb16 WHERE c4 = 50 ORDER BY c1 LIMIT 100;
+SELECT c1, c2 FROM mb64 WHERE c4 = 50 ORDER BY c1 LIMIT 100;
+SELECT c1, c2 FROM mplain WHERE c4 = 50 ORDER BY c1 LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- No LIMIT anywhere.  Only the reference pair runs this shape, since the
+-- result is the whole table and the point is the shape of the cost, not a
+-- fifth data point.  The first-page gate is paid here too, so a model that
+-- charges startup only when a LIMIT is present is charging in the wrong
+-- place.
+-- ---------------------------------------------------------------------
+SELECT c1 FROM mb16 ORDER BY c1;
+SELECT c1 FROM mplain ORDER BY c1;

--- a/sql/cost-validation-bucketized-v2/queries/merge-02-limit-and-aggregates.sql
+++ b/sql/cost-validation-bucketized-v2/queries/merge-02-limit-and-aggregates.sql
@@ -1,0 +1,118 @@
+-- Merge scan: how LIMIT is priced, and what happens when no LIMIT reaches
+-- the scan at all.
+--
+-- An ordered scan under a LIMIT is priced assuming it stops early.  For a
+-- merge scan that assumption is doubly optimistic: the LIMIT is stamped on
+-- the template read op before it is cloned, so the first fetch round asks
+-- every stream for min(LIMIT, yb_fetch_row_limit) rows, and a stream that has
+-- to page again resets its limit to the full fetch page rather than to what
+-- the query still needs.  Cost should therefore be flat inside a fetch page
+-- and step across it, and it should scale with the stream count in both
+-- regimes.
+--
+-- The second half of the file removes the LIMIT from the scan's reach.  An
+-- aggregate consumes every input row, so any early-termination discount the
+-- model applied is unearned, and how badly that shows depends on how
+-- aggressive the discount is.  These queries are the constraint on how far
+-- the LIMIT discount in a corrected model is allowed to go.
+
+
+-- ---------------------------------------------------------------------
+-- LIMIT sweep across the default 1024-row fetch page on the 16-bucket
+-- table.  Costs and times should be flat from 1 to 1024 and step at 1025.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 1;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 100;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 512;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 1023;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 1024;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 1025;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 2048;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 2049;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 10000;
+
+
+-- ---------------------------------------------------------------------
+-- The same sweep at 64 streams, where each step of the boundary costs 64
+-- times as much fetch work as it does on mplain.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb64 ORDER BY c1 LIMIT 1023;
+SELECT c1, c2 FROM mb64 ORDER BY c1 LIMIT 1025;
+SELECT c1, c2 FROM mb64 ORDER BY c1 LIMIT 2049;
+SELECT c1, c2 FROM mb64 ORDER BY c1 LIMIT 10000;
+
+
+-- ---------------------------------------------------------------------
+-- The same sweep with no streams, as the reference for the two above.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mplain ORDER BY c1 LIMIT 1023;
+SELECT c1, c2 FROM mplain ORDER BY c1 LIMIT 1025;
+SELECT c1, c2 FROM mplain ORDER BY c1 LIMIT 2049;
+SELECT c1, c2 FROM mplain ORDER BY c1 LIMIT 10000;
+
+
+-- ---------------------------------------------------------------------
+-- OFFSET pushes the boundary without changing the result size.  The scan
+-- must produce offset + limit rows, so the cost should track the sum.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb16 ORDER BY c1 OFFSET 1000 LIMIT 10;
+SELECT c1, c2 FROM mb16 ORDER BY c1 OFFSET 10000 LIMIT 10;
+SELECT c1, c2 FROM mb16 ORDER BY c1 OFFSET 100000 LIMIT 10;
+SELECT c1, c2 FROM mb64 ORDER BY c1 OFFSET 100000 LIMIT 10;
+SELECT c1, c2 FROM mplain ORDER BY c1 OFFSET 100000 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- A LIMIT under a subquery boundary still reaches the scan.  Its twin
+-- below, with the aggregate on the outside, does not stop the scan early
+-- but does return one row, so the two isolate the discount from the volume
+-- of rows returned.
+-- ---------------------------------------------------------------------
+SELECT count(*) FROM (SELECT c1 FROM mb16 ORDER BY c1 LIMIT 1000) s;
+SELECT count(*) FROM (SELECT c1 FROM mb64 ORDER BY c1 LIMIT 1000) s;
+SELECT count(*) FROM (SELECT c1 FROM mplain ORDER BY c1 LIMIT 1000) s;
+
+
+-- ---------------------------------------------------------------------
+-- Aggregates over the whole table.  No LIMIT reaches the scan, so ordering
+-- buys nothing and any merge path here is pure overhead.
+-- ---------------------------------------------------------------------
+SELECT count(*) FROM mb16;
+SELECT count(*) FROM mb64;
+SELECT count(*) FROM mplain;
+SELECT avg(c4) FROM mb16;
+SELECT avg(c4) FROM mb64;
+SELECT avg(c4) FROM mplain;
+SELECT count(*) FROM mb16 WHERE c4 = 50;
+SELECT count(*) FROM mb64 WHERE c4 = 50;
+SELECT count(*) FROM mplain WHERE c4 = 50;
+
+
+-- ---------------------------------------------------------------------
+-- min and max on the second key column.  On mplain this is one seek to
+-- either end of the index.  On the bucketized tables the extreme is
+-- whichever bucket happens to hold it, so the answer requires touching all
+-- of them, and whether the planner charges for that is the question.
+-- ---------------------------------------------------------------------
+SELECT min(c1) FROM mb16;
+SELECT max(c1) FROM mb16;
+SELECT min(c1) FROM mb64;
+SELECT max(c1) FROM mb64;
+SELECT min(c1) FROM mplain;
+SELECT max(c1) FROM mplain;
+SELECT min(c1), max(c1) FROM mb16;
+SELECT min(c1), max(c1) FROM mplain;
+
+
+-- ---------------------------------------------------------------------
+-- Grouping consumes every row regardless of the LIMIT above it, but the
+-- ordered input can still save the sort, so these are the cases where the
+-- merge path earns something without earning early termination.
+-- ---------------------------------------------------------------------
+SELECT c1, count(*) FROM mb16 GROUP BY c1 ORDER BY c1 LIMIT 100;
+SELECT c1, count(*) FROM mb64 GROUP BY c1 ORDER BY c1 LIMIT 100;
+SELECT c1, count(*) FROM mplain GROUP BY c1 ORDER BY c1 LIMIT 100;
+SELECT c4, count(*) FROM mb16 GROUP BY c4 ORDER BY c4 LIMIT 10;
+SELECT c4, count(*) FROM mb64 GROUP BY c4 ORDER BY c4 LIMIT 10;
+SELECT c4, count(*) FROM mplain GROUP BY c4 ORDER BY c4 LIMIT 10;

--- a/sql/cost-validation-bucketized-v2/queries/merge-03-width.sql
+++ b/sql/cost-validation-bucketized-v2/queries/merge-03-width.sql
@@ -1,0 +1,84 @@
+-- Merge scan: sensitivity to row width.
+--
+-- mn16 and mw16 hold the same 50000 rows in the same 16-bucket layout and
+-- differ only in the width of v, 64 characters against 4096.  Every query
+-- below runs on both, so within a pair the bytes per row are the only
+-- variable.  mb16 appears in a few places as the same schema at ten times the
+-- rows, which separates width from row count.
+--
+-- Why width matters more for a merge scan than for a plain ordered scan: the
+-- first fetch round asks every stream for min(LIMIT, fetch page) rows at
+-- once, so the bytes in flight are stream count times LIMIT times row width
+-- rather than LIMIT times row width.  At 16 streams, LIMIT 1000 and 4 KB
+-- rows that is 64 MB moved to return 4 MB.  A plain ordered scan on the same
+-- data moves the 4 MB and nothing more.  The cost model charges a flat 2 %
+-- over the plain scan in both cases.
+--
+-- Note that selecting v is what makes width bite.  The narrow projections
+-- below are the control: they read the same index entries and should show
+-- little difference between the two tables.
+
+
+-- ---------------------------------------------------------------------
+-- Narrow projection, the control.  v is never touched, so the two tables
+-- should behave alike.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mn16 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mw16 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mn16 ORDER BY c1 LIMIT 100;
+SELECT c1, c2 FROM mw16 ORDER BY c1 LIMIT 100;
+SELECT c1, c2 FROM mn16 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mw16 ORDER BY c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- Wide projection at the same limits.  This is the same query grid with v
+-- added, so the difference between this block and the one above is exactly
+-- the cost of moving the payload through the streams.
+-- ---------------------------------------------------------------------
+SELECT c1, c2, v FROM mn16 ORDER BY c1 LIMIT 10;
+SELECT c1, c2, v FROM mw16 ORDER BY c1 LIMIT 10;
+SELECT c1, c2, v FROM mn16 ORDER BY c1 LIMIT 100;
+SELECT c1, c2, v FROM mw16 ORDER BY c1 LIMIT 100;
+SELECT c1, c2, v FROM mn16 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2, v FROM mw16 ORDER BY c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- SELECT * at a small limit, the shape an application actually writes.
+-- ---------------------------------------------------------------------
+SELECT * FROM mn16 ORDER BY c1 LIMIT 10;
+SELECT * FROM mw16 ORDER BY c1 LIMIT 10;
+SELECT * FROM mn16 ORDER BY c1 DESC LIMIT 10;
+SELECT * FROM mw16 ORDER BY c1 DESC LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- Filtered, so more rows must be read per row returned and the wasted
+-- bytes multiply accordingly.  About one row in a hundred qualifies.
+-- ---------------------------------------------------------------------
+SELECT c1, c2, v FROM mn16 WHERE c4 = 50 ORDER BY c1 LIMIT 50;
+SELECT c1, c2, v FROM mw16 WHERE c4 = 50 ORDER BY c1 LIMIT 50;
+SELECT c1, c2 FROM mn16 WHERE c4 = 50 ORDER BY c1 LIMIT 50;
+SELECT c1, c2 FROM mw16 WHERE c4 = 50 ORDER BY c1 LIMIT 50;
+
+
+-- ---------------------------------------------------------------------
+-- Full drain with a small result, so the whole table passes through the
+-- ordered path at both widths.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mn16 ORDER BY c1 OFFSET 49990 LIMIT 10;
+SELECT c1, c2 FROM mw16 ORDER BY c1 OFFSET 49990 LIMIT 10;
+SELECT c1, c2, v FROM mn16 ORDER BY c1 OFFSET 49990 LIMIT 10;
+SELECT c1, c2, v FROM mw16 ORDER BY c1 OFFSET 49990 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- Row count against width.  mb16 is mn16 with ten times the rows and the
+-- narrow payload, so comparing the three tells whether the model's response
+-- to width and to row count are separately right.
+-- ---------------------------------------------------------------------
+SELECT c1, c2, v FROM mb16 ORDER BY c1 LIMIT 1000;
+SELECT count(*) FROM mn16 WHERE c4 = 50;
+SELECT count(*) FROM mw16 WHERE c4 = 50;
+SELECT count(*) FROM mb16 WHERE c4 = 50;

--- a/sql/cost-validation-bucketized-v2/queries/merge-04-user-inlist.sql
+++ b/sql/cost-validation-bucketized-v2/queries/merge-04-user-inlist.sql
@@ -1,0 +1,132 @@
+-- Merge scan on user-written IN lists, with no bucketization anywhere.
+--
+-- Merge scan is not a bucketized-index feature.  Any range index whose
+-- leading column carries an IN list engages it, which is most of the existing
+-- exposure, and sa has no bucket column and no generated column, so neither
+-- derived-clause GUC can touch these plans.  What is left is the merge scan
+-- cost model on its own.
+--
+-- The question each query asks is whether a merge over the IN elements beats
+-- a sort over the same index scan, or a sort over a sequential scan.  Note
+-- that on this table nothing else can supply c1 order: sa has no (c1 asc)
+-- index, because that is the index a real deployment would find hot.  The
+-- rival suite covers the case where one exists anyway.
+--
+-- Data facts.  c3 has ndv 1000 with 500 rows per value, c4 has ndv 100 with
+-- 5000, and c6 has ndv 10 with 50000.  So an IN list of k elements selects
+-- k/1000, k/100 or k/10 of the table respectively, and the three indexes give
+-- the same stream count at three very different selectivities.
+--
+-- Layout note.  sa's secondary indexes are single tablet, the YB default for
+-- a secondary range index.  That makes the 32 and 64 stream queries below the
+-- model's exposure to yugabyte/yugabyte-db#33247, where streams sharing a
+-- tablet split one response-size budget, so their timings carry that defect
+-- as well as the cost model's error.  The stream counts and read-op counts
+-- are still meaningful, and the equivalent bucketized queries in merge-01 run
+-- one stream per tablet for contrast.
+
+
+-- ---------------------------------------------------------------------
+-- Stream count sweep at high selectivity, 500 rows per element.  The merge
+-- has to be worth its startup against a sort of at most 32000 rows.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2) ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4) ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8) ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16) ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32) ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64) ORDER BY c1 LIMIT 10;
+
+-- One element past the 64 stream cap.  Merge scan is not reduced to 64
+-- streams, it is switched off for that column entirely, so the plan changes
+-- shape rather than degrading, and the estimate jumps with it.
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65) ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- Range twins of the sweep.  BETWEEN 1 AND k selects exactly the rows that
+-- IN (1..k) selects, but a range is not a scalar array operation, so no
+-- merge is possible and the planner must sort.  Each pair isolates the
+-- merge from every other difference, including selectivity.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM sa WHERE c3 BETWEEN 1 AND 4 ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 BETWEEN 1 AND 16 ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 BETWEEN 1 AND 64 ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 BETWEEN 1 AND 65 ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- A single element needs no merge at all: one seek, already ordered.  This
+-- is the floor the sweep above starts from.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM sa WHERE c3 = 1 ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 = 1 ORDER BY c1 LIMIT 500;
+SELECT c1, c3 FROM sa WHERE c3 = 1 ORDER BY c1;
+
+
+-- ---------------------------------------------------------------------
+-- The sweep again past the fetch page, where each stream is handed 1024
+-- rows rather than the LIMIT.  At 64 streams that is 65536 rows read to
+-- return 1000.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4) ORDER BY c1 LIMIT 1000;
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16) ORDER BY c1 LIMIT 1000;
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64) ORDER BY c1 LIMIT 1000;
+SELECT c1, c3 FROM sa WHERE c3 BETWEEN 1 AND 64 ORDER BY c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- Same stream counts, a hundred times less selective, on c4.  Whether a
+-- merge is right depends on how much of the table the IN list admits, so
+-- these are the same plans over very different row counts.
+-- ---------------------------------------------------------------------
+SELECT c1, c4 FROM sa WHERE c4 IN (1,2) ORDER BY c1 LIMIT 10;
+SELECT c1, c4 FROM sa WHERE c4 IN (1,2,3,4,5,6,7,8) ORDER BY c1 LIMIT 10;
+SELECT c1, c4 FROM sa WHERE c4 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32) ORDER BY c1 LIMIT 10;
+SELECT c1, c4 FROM sa WHERE c4 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64) ORDER BY c1 LIMIT 10;
+SELECT c1, c4 FROM sa WHERE c4 IN (1,2,3,4,5,6,7,8) ORDER BY c1 LIMIT 1000;
+SELECT c1, c4 FROM sa WHERE c4 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64) ORDER BY c1 LIMIT 1000;
+SELECT c1, c4 FROM sa WHERE c4 BETWEEN 1 AND 64 ORDER BY c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- Very few streams over very many rows, on c6.  Two elements are a fifth of
+-- the table, so the merge is cheap to start and expensive to drain, which
+-- is the opposite balance from the c3 block.
+-- ---------------------------------------------------------------------
+SELECT c1, c6 FROM sa WHERE c6 IN (1,2) ORDER BY c1 LIMIT 10;
+SELECT c1, c6 FROM sa WHERE c6 IN (1,2,3,4) ORDER BY c1 LIMIT 10;
+SELECT c1, c6 FROM sa WHERE c6 IN (1,2,3,4,5,6,7,8) ORDER BY c1 LIMIT 10;
+SELECT c1, c6 FROM sa WHERE c6 IN (1,2) ORDER BY c1 LIMIT 10000;
+SELECT c1, c6 FROM sa WHERE c6 IN (1,2,3,4,5,6,7,8) ORDER BY c1 LIMIT 10000;
+SELECT c1, c6 FROM sa WHERE c6 BETWEEN 1 AND 8 ORDER BY c1 LIMIT 10000;
+
+
+-- ---------------------------------------------------------------------
+-- No ORDER BY, so the merge has nothing to sell.  Any merge path chosen
+-- here is paying for an order the query never asked for.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64);
+SELECT count(*) FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+SELECT count(*) FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64);
+SELECT count(*) FROM sa WHERE c4 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64);
+
+
+-- ---------------------------------------------------------------------
+-- Ordered and fully drained, so the merge saves a sort but earns no early
+-- termination.  The OFFSET keeps the result small so the row count returned
+-- does not confound the timing.
+-- ---------------------------------------------------------------------
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16) ORDER BY c1 OFFSET 7990 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64) ORDER BY c1 OFFSET 31990 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 BETWEEN 1 AND 64 ORDER BY c1 OFFSET 31990 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- An extra ordering key the index cannot supply, so the choice is between
+-- an incremental sort over a merge and a full sort over a plain scan.
+-- ---------------------------------------------------------------------
+SELECT c1, c3, c5 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16) ORDER BY c1, c5 LIMIT 10;
+SELECT c1, c3, c5 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64) ORDER BY c1, c5 LIMIT 10;
+SELECT c1, c3, c5 FROM sa WHERE c3 BETWEEN 1 AND 64 ORDER BY c1, c5 LIMIT 10;

--- a/sql/cost-validation-bucketized-v2/queries/merge-05-stream-product.sql
+++ b/sql/cost-validation-bucketized-v2/queries/merge-05-stream-product.sql
@@ -1,0 +1,92 @@
+-- Merge scan: stream cardinality as a cartesian product.
+--
+-- ms16's primary key is (c0, c6, c1) with 16 buckets, so a query that orders
+-- by c1 needs a stream for every combination of bucket and c6 value it
+-- admits.  The planner derives the 16-element SAOP on c0 and multiplies it by
+-- whatever the user wrote on c6, giving 16, 32, 48, 64 and 80 streams from IN
+-- lists of one to five elements.  The product is what the cap in
+-- yb_max_merge_scan_streams actually limits, and crossing it does not reduce
+-- the stream count, it removes merge scan from that column entirely, so the
+-- plan changes shape and the estimate jumps with it.
+--
+-- This also stresses the layout assumption behind the presplit rule.  ms16
+-- has one tablet per bucket, but a product of 64 streams over 16 tablets puts
+-- four streams in every tablet, which is the configuration
+-- yugabyte/yugabyte-db#33247 describes.  Multi-column merges cannot be split
+-- out of that defect by any layout, which is why the issue lists them
+-- separately from user IN lists.
+--
+-- Data facts: 300000 rows, c6 has ndv 10 with 30000 rows per value, and the
+-- buckets are even to within sampling noise.
+
+
+-- ---------------------------------------------------------------------
+-- The product sweep at a small LIMIT.  One c6 value gives 16 streams, five
+-- give 80 and merge scan disappears.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM ms16 WHERE c6 = 1 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM ms16 WHERE c6 IN (1,2) ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM ms16 WHERE c6 IN (1,2,3) ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM ms16 WHERE c6 IN (1,2,3,4) ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM ms16 WHERE c6 IN (1,2,3,4,5) ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM ms16 WHERE c6 IN (1,2,3,4,5,6,7,8) ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- Range twins.  BETWEEN 1 AND k admits the same rows as the IN list but is
+-- not a scalar array operation, so there is no product and no merge.  The
+-- pair at k = 4 is the cleanest comparison in this file: same rows, same
+-- index, 64 streams against a sort.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM ms16 WHERE c6 BETWEEN 1 AND 2 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM ms16 WHERE c6 BETWEEN 1 AND 4 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM ms16 WHERE c6 BETWEEN 1 AND 5 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM ms16 WHERE c6 BETWEEN 1 AND 8 ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- The product sweep past the fetch page.  Each of the 64 streams is handed
+-- 1024 rows, so about 65000 rows are read to return 1000, and the streams
+-- share 16 tablets while doing it.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM ms16 WHERE c6 = 1 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM ms16 WHERE c6 IN (1,2) ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM ms16 WHERE c6 IN (1,2,3,4) ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM ms16 WHERE c6 IN (1,2,3,4,5) ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM ms16 WHERE c6 BETWEEN 1 AND 4 ORDER BY c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- No predicate on c6 at all.  The derived bucket SAOP alone cannot deliver
+-- c1 order, because c6 sits between the bucket and c1 in the key, so this
+-- has to sort no matter what the stream cap is.  It is the control showing
+-- that the merge in every query above depends on the user's IN list.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM ms16 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM ms16 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2, c6 FROM ms16 ORDER BY c6, c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- The user writing the bucket predicate themselves.  This is the shape that
+-- makes the row estimate unstable: a full-domain IN on the bucket column
+-- goes through clause selectivity, where the disjoint sum lands on the 1.0
+-- boundary and the estimate flips between all rows and about 0.64 of them
+-- across ANALYZE runs (yugabyte/yugabyte-db#33251).  A partial list is not
+-- on the boundary and is the control for it.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM ms16 WHERE c0 IN (0,1,2,3) AND c6 IN (1,2) ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM ms16 WHERE c0 IN (0,1,2,3) AND c6 IN (1,2,3,4) ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM ms16 WHERE c0 = 0 AND c6 IN (1,2,3,4) ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM ms16 WHERE c0 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15) AND c6 IN (1,2) ORDER BY c1 LIMIT 10;
+SELECT count(*) FROM ms16 WHERE c0 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15);
+
+
+-- ---------------------------------------------------------------------
+-- Fully drained products, where the merge saves the sort but nothing else.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM ms16 WHERE c6 IN (1,2) ORDER BY c1 OFFSET 59990 LIMIT 10;
+SELECT c1, c2 FROM ms16 WHERE c6 IN (1,2,3,4) ORDER BY c1 OFFSET 119990 LIMIT 10;
+SELECT c1, c2 FROM ms16 WHERE c6 BETWEEN 1 AND 4 ORDER BY c1 OFFSET 119990 LIMIT 10;
+SELECT count(*) FROM ms16 WHERE c6 IN (1,2,3,4);
+SELECT c6, count(*) FROM ms16 WHERE c6 IN (1,2,3,4) GROUP BY c6 ORDER BY c6;

--- a/sql/cost-validation-bucketized-v2/queries/merge-06-order-shapes.sql
+++ b/sql/cost-validation-bucketized-v2/queries/merge-06-order-shapes.sql
@@ -1,0 +1,107 @@
+-- Merge scan: the shapes that consume an ordering.
+--
+-- A merge scan is only ever worth its overhead because something above it
+-- wants sorted rows.  ORDER BY is the obvious consumer, but it is not the
+-- only one, and the others price the ordering differently: an incremental
+-- sort needs only a prefix, a merge join needs both inputs ordered, a group
+-- aggregate can take sorted input instead of building a hash table, and
+-- DISTINCT ON needs the ordering it is defined by.  Each of those is a
+-- separate decision the cost model makes with the same 2 % merge premium
+-- underneath it.
+--
+-- Every query runs on mb16 and on mplain, the same rows with and without
+-- streams, so the pair shows what the ordering is worth when it costs
+-- 16 streams against when it costs nothing.  Several also run on mb64, where
+-- the same ordering costs four times as many streams for the same benefit.
+
+
+-- ---------------------------------------------------------------------
+-- Ordering the index supplies in full, against ordering that needs a sort
+-- on top.  c2 follows c1 in the bucketized key, so (c1, c2) is free once
+-- the merge is running, while c5 is not in the index at all.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb16 ORDER BY c1, c2 LIMIT 100;
+SELECT c1, c2 FROM mplain ORDER BY c1, c2 LIMIT 100;
+SELECT c1, c2, c5 FROM mb16 ORDER BY c1, c5 LIMIT 100;
+SELECT c1, c2, c5 FROM mplain ORDER BY c1, c5 LIMIT 100;
+SELECT c1, c2, c5 FROM mb64 ORDER BY c1, c5 LIMIT 100;
+SELECT c1, c2, c5 FROM mb16 ORDER BY c1, c5 LIMIT 10000;
+SELECT c1, c2, c5 FROM mplain ORDER BY c1, c5 LIMIT 10000;
+
+
+-- ---------------------------------------------------------------------
+-- Mixed direction, which no single index scan can supply, so the merge can
+-- at best feed an incremental sort.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb16 ORDER BY c1 ASC, c2 DESC LIMIT 100;
+SELECT c1, c2 FROM mplain ORDER BY c1 ASC, c2 DESC LIMIT 100;
+SELECT c1, c2 FROM mb16 ORDER BY c1 DESC, c2 DESC LIMIT 100;
+SELECT c1, c2 FROM mplain ORDER BY c1 DESC, c2 DESC LIMIT 100;
+SELECT c1, c2 FROM mb64 ORDER BY c1 DESC, c2 DESC LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- DISTINCT ON, which is defined by its ordering and cannot be answered by a
+-- hash aggregate.  c1 is unique here, so every input row is also an output
+-- row and the ordering is the whole cost.
+-- ---------------------------------------------------------------------
+SELECT DISTINCT ON (c1) c1, c2, c4 FROM mb16 ORDER BY c1, c2 LIMIT 100;
+SELECT DISTINCT ON (c1) c1, c2, c4 FROM mplain ORDER BY c1, c2 LIMIT 100;
+SELECT DISTINCT ON (c4) c4, c1, c2 FROM mb16 ORDER BY c4, c1;
+SELECT DISTINCT ON (c4) c4, c1, c2 FROM mplain ORDER BY c4, c1;
+
+
+-- ---------------------------------------------------------------------
+-- Grouping on the ordered column.  A group aggregate over sorted input
+-- competes with a hash aggregate over an unordered scan, and the merge
+-- premium is what tips it.  Grouping on c4 instead needs a sort either way,
+-- which is the control.
+-- ---------------------------------------------------------------------
+SELECT c1, count(*) FROM mb16 GROUP BY c1 ORDER BY c1 LIMIT 1000;
+SELECT c1, count(*) FROM mplain GROUP BY c1 ORDER BY c1 LIMIT 1000;
+SELECT c1, count(*) FROM mb64 GROUP BY c1 ORDER BY c1 LIMIT 1000;
+SELECT c1, sum(c4) FROM mb16 WHERE c4 > 90 GROUP BY c1 ORDER BY c1 LIMIT 1000;
+SELECT c1, sum(c4) FROM mplain WHERE c4 > 90 GROUP BY c1 ORDER BY c1 LIMIT 1000;
+SELECT c4, count(*) FROM mb16 GROUP BY c4 ORDER BY c4;
+SELECT c4, count(*) FROM mplain GROUP BY c4 ORDER BY c4;
+
+
+-- ---------------------------------------------------------------------
+-- Window functions, where the frame's ORDER BY is the consumer and there is
+-- no LIMIT the scan can use even when one sits above the window.
+-- ---------------------------------------------------------------------
+SELECT c1, c4, row_number() OVER (ORDER BY c1) FROM mb16 LIMIT 100;
+SELECT c1, c4, row_number() OVER (ORDER BY c1) FROM mplain LIMIT 100;
+SELECT c1, c4, sum(c4) OVER (ORDER BY c1 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM mb16 LIMIT 100;
+SELECT c1, c4, sum(c4) OVER (ORDER BY c1 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM mplain LIMIT 100;
+SELECT c4, c1, rank() OVER (PARTITION BY c4 ORDER BY c1) FROM mb16 WHERE c4 IN (1,2,3) LIMIT 100;
+SELECT c4, c1, rank() OVER (PARTITION BY c4 ORDER BY c1) FROM mplain WHERE c4 IN (1,2,3) LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- SELECT DISTINCT, which can take either a sorted input or a hash.
+-- ---------------------------------------------------------------------
+SELECT DISTINCT c1 FROM mb16 ORDER BY c1 LIMIT 1000;
+SELECT DISTINCT c1 FROM mplain ORDER BY c1 LIMIT 1000;
+SELECT DISTINCT c4 FROM mb16 ORDER BY c4;
+SELECT DISTINCT c4 FROM mplain ORDER BY c4;
+
+
+-- ---------------------------------------------------------------------
+-- Set operations, where the ordering above the union has to be produced
+-- after the branches are combined.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb16 WHERE c4 = 1 UNION ALL SELECT c1, c2 FROM mb16 WHERE c4 = 2 ORDER BY c1 LIMIT 100;
+SELECT c1, c2 FROM mplain WHERE c4 = 1 UNION ALL SELECT c1, c2 FROM mplain WHERE c4 = 2 ORDER BY c1 LIMIT 100;
+SELECT c1 FROM mb16 WHERE c4 = 1 UNION SELECT c1 FROM mb16 WHERE c4 = 2 ORDER BY c1 LIMIT 100;
+SELECT c1 FROM mplain WHERE c4 = 1 UNION SELECT c1 FROM mplain WHERE c4 = 2 ORDER BY c1 LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- Ordering wanted only inside a subquery, where the LIMIT above cannot be
+-- pushed to the scan.
+-- ---------------------------------------------------------------------
+SELECT max(c1) FROM (SELECT c1 FROM mb16 ORDER BY c1 LIMIT 10000) s;
+SELECT max(c1) FROM (SELECT c1 FROM mplain ORDER BY c1 LIMIT 10000) s;
+SELECT count(*) FROM (SELECT DISTINCT ON (c4) c4, c1 FROM mb16 ORDER BY c4, c1) s;
+SELECT count(*) FROM (SELECT DISTINCT ON (c4) c4, c1 FROM mplain ORDER BY c4, c1) s;

--- a/sql/cost-validation-bucketized-v2/queries/merge-07-limit-bets.sql
+++ b/sql/cost-validation-bucketized-v2/queries/merge-07-limit-bets.sql
@@ -1,0 +1,165 @@
+-- Merge scan: the LIMIT bet, swept across estimate error.
+--
+-- An ordered scan under a LIMIT is priced assuming it stops as soon as it has
+-- enough rows, so its cost is the full scan cost scaled by limit / estimated
+-- rows.  A merge scan wins that pricing easily, because it is the only plan
+-- that produces order without materializing anything, and its rival has to
+-- sort.  The bet is only as good as the estimate underneath it, and when the
+-- estimate is wrong the merge plan does not degrade gracefully: it drains
+-- every stream at a full fetch page each while the sort plan does the work it
+-- was always going to do.
+--
+-- The largest regression the previous model finds is exactly this, at 1349x:
+-- v LIKE 'zz%' ORDER BY c1, c2 LIMIT 10, where a 3-stream merge with the LIKE
+-- as a storage filter was costed at 124 against 2851 for a selective index
+-- scan plus a sort, and then scanned all 1000000 rows to return nothing.
+--
+-- It would be easy to read that as a bug about empty results, and it is not.
+-- In that run the regression rate is flat across output sizes: 29 % of the
+-- queries returning no rows regressed, 31 % of those returning one row, 30 %
+-- returning 11 to 100, and 29 % returning 101 to 10000.  Only above 10000
+-- rows does it fall away, to 6 %.  Returning nothing does not cause the wrong
+-- plan, it removes the early exit that would have hidden it, so the same
+-- error shows up as 1349x instead of 1.4x.  This file therefore sweeps the
+-- estimate error rather than camping on the corner, and the empty cases are
+-- the endpoint of that sweep.
+--
+-- The instrument is c7 and c8.  c8 equals c7 in every row but the first,
+-- where it is c7 + 1, and there are no extended statistics, so the estimator
+-- predicts about 50 rows for all three of these while the truth is very
+-- different:
+--
+--   c7 = 2  AND c8 = 2    4999 rows    estimate about 100x too low
+--   c7 = 2  AND c8 = 3       1 row     estimate about 50x too high
+--   c7 = 50 AND c8 = 51      0 rows    estimate infinitely too high
+--
+-- Three tables answer the same queries.  sel has plain indexes on c3, c7 and
+-- v, so a genuinely selective access path exists and the question is whether
+-- the CBO picks it.  mb16 has only its bucketized primary key, so the merge
+-- path is the only path and the question is how much the bad bet costs.
+-- mplain has no streams at all and is the floor.
+
+
+-- ---------------------------------------------------------------------
+-- The ladder with a selective rival available.  All three estimate about
+-- 50 rows, so any cost difference between them is the model reacting to
+-- something other than the estimate, and any plan difference from the
+-- honest c7 = 2 row below is the estimate error changing the choice.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM sel WHERE c7 = 2 AND c8 = 2 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM sel WHERE c7 = 2 AND c8 = 3 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM sel WHERE c7 = 50 AND c8 = 51 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM sel WHERE c7 = 2 ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- The same ladder with no rival, where the merge path is the only ordered
+-- path and the cost of the bad bet is paid in full.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb16 WHERE c7 = 2 AND c8 = 2 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE c7 = 2 AND c8 = 3 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE c7 = 50 AND c8 = 51 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE c7 = 2 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb64 WHERE c7 = 2 AND c8 = 2 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb64 WHERE c7 = 2 AND c8 = 3 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb64 WHERE c7 = 50 AND c8 = 51 ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- And with no streams, which is what the two blocks above are paying extra
+-- for.  The same three estimate errors cost a plain ordered scan very
+-- little, because there is nothing to multiply by the stream count.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mplain WHERE c7 = 2 AND c8 = 2 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mplain WHERE c7 = 2 AND c8 = 3 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mplain WHERE c7 = 50 AND c8 = 51 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mplain WHERE c7 = 2 ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- Honest estimates, the control for the whole file.  c3 = 500 selects 500
+-- rows and is estimated at 496, c4 = 50 selects 5000, and a range over c3
+-- selects 25000.  If the merge path is mispriced here too, the estimate
+-- error was never the cause.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM sel WHERE c3 = 500 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE c3 = 500 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mplain WHERE c3 = 500 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM sel WHERE c4 = 50 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE c4 = 50 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mplain WHERE c4 = 50 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM sel WHERE c3 BETWEEN 1 AND 50 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE c3 BETWEEN 1 AND 50 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mplain WHERE c3 BETWEEN 1 AND 50 ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- The reported shape: an opaque string predicate with a real index range
+-- behind it.  v is 64 characters starting with '-' in every row, so
+-- v LIKE 'zz%' matches nothing while the planner derives a prefix range,
+-- and v LIKE '--%' matches everything.  sel_vc1 is the selective rival that
+-- the merge plan has to beat, and mb16 is the same query with no rival.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM sel WHERE v LIKE 'zz%' ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM sel WHERE v LIKE '--%' ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE v LIKE 'zz%' ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE v LIKE '--%' ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb64 WHERE v LIKE 'zz%' ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mplain WHERE v LIKE 'zz%' ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mplain WHERE v LIKE '--%' ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mw16 WHERE v LIKE 'zz%' ORDER BY c1 LIMIT 10;
+SELECT c1, c2, v FROM mw16 WHERE v LIKE 'zz%' ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- Opaque with no index behind it at all, so the estimate is a bare default
+-- and the merge plan's only rival is a sequential scan and a sort.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM sel WHERE length(v) BETWEEN 10 AND 20 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM sel WHERE length(v) = 64 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE length(v) BETWEEN 10 AND 20 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE length(v) = 64 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mplain WHERE length(v) BETWEEN 10 AND 20 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mplain WHERE length(v) = 64 ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- How the LIMIT size changes the bet.  The discount is limit / estimated
+-- rows, so a LIMIT above the estimate removes it entirely and the plans
+-- should converge.  The estimate is about 50, so 10 bets, 100 does not.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM sel WHERE c7 = 50 AND c8 = 51 ORDER BY c1 LIMIT 1;
+SELECT c1, c2 FROM sel WHERE c7 = 50 AND c8 = 51 ORDER BY c1 LIMIT 100;
+SELECT c1, c2 FROM sel WHERE c7 = 50 AND c8 = 51 ORDER BY c1;
+SELECT c1, c2 FROM mb16 WHERE c7 = 50 AND c8 = 51 ORDER BY c1 LIMIT 1;
+SELECT c1, c2 FROM mb16 WHERE c7 = 50 AND c8 = 51 ORDER BY c1 LIMIT 100;
+SELECT c1, c2 FROM mb16 WHERE c7 = 50 AND c8 = 51 ORDER BY c1;
+SELECT c1, c2 FROM mb16 WHERE c7 = 2 AND c8 = 2 ORDER BY c1 LIMIT 100;
+SELECT c1, c2 FROM mb16 WHERE c7 = 2 AND c8 = 2 ORDER BY c1 LIMIT 5000;
+
+
+-- ---------------------------------------------------------------------
+-- No LIMIT, so there was never a bet.  Any difference here is the cost of
+-- the streams and the sort, which is what the bet was being made against.
+-- ---------------------------------------------------------------------
+SELECT count(*) FROM sel WHERE c7 = 2 AND c8 = 2;
+SELECT count(*) FROM sel WHERE c7 = 50 AND c8 = 51;
+SELECT count(*) FROM mb16 WHERE c7 = 2 AND c8 = 2;
+SELECT count(*) FROM mb16 WHERE c7 = 50 AND c8 = 51;
+SELECT count(*) FROM mb16 WHERE v LIKE 'zz%';
+SELECT count(*) FROM mplain WHERE v LIKE 'zz%';
+
+
+-- ---------------------------------------------------------------------
+-- The bet inside a join, where a scan that never terminates early keeps a
+-- join driving above it.  This is the shape of the 280x regression in the
+-- previous model, an aggregate over a join whose filter matches nothing.
+-- ---------------------------------------------------------------------
+SELECT s.c1, count(*) FROM sel s JOIN dj d ON d.c1 = s.c1 WHERE s.c7 = 50 AND s.c8 = 51 GROUP BY s.c1 ORDER BY s.c1 LIMIT 100;
+SELECT s.c1, count(*) FROM sel s JOIN dj d ON d.c1 = s.c1 WHERE s.c7 = 2 AND s.c8 = 2 GROUP BY s.c1 ORDER BY s.c1 LIMIT 100;
+SELECT m.c1, count(*) FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE m.c7 = 50 AND m.c8 = 51 GROUP BY m.c1 ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, count(*) FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE m.c7 = 2 AND m.c8 = 2 GROUP BY m.c1 ORDER BY m.c1 LIMIT 100;
+SELECT p.c1, count(*) FROM mplain p JOIN dj d ON d.c1 = p.c1 WHERE p.c7 = 50 AND p.c8 = 51 GROUP BY p.c1 ORDER BY p.c1 LIMIT 100;
+SELECT p.c1, count(*) FROM mplain p JOIN dj d ON d.c1 = p.c1 WHERE p.c7 = 2 AND p.c8 = 2 GROUP BY p.c1 ORDER BY p.c1 LIMIT 100;
+SELECT m.c1, d.c4 FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE m.v LIKE 'zz%' ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, d.c4 FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE m.v LIKE '--%' ORDER BY m.c1 LIMIT 100;

--- a/sql/cost-validation-bucketized-v2/queries/merge-08-joins.sql
+++ b/sql/cost-validation-bucketized-v2/queries/merge-08-joins.sql
@@ -1,0 +1,119 @@
+-- Merge scan inside joins.
+--
+-- A scan cost error that is small in isolation becomes a plan error when it
+-- decides a join.  Three things can go wrong here that cannot go wrong in a
+-- bare scan.  A merge scan priced too cheaply can win the inner side of a
+-- nested loop, where its per-parameter startup is paid once per outer row
+-- rather than once per query.  Its free ordering can entice a merge join that
+-- would otherwise have been a hash join.  And because a merge path exists
+-- where an ordered path did not, it can flip the join order outright, which
+-- is the mechanism in yugabyte/yugabyte-db#32317 and has its own file.
+--
+-- dj holds 20000 rows with c1 = 1..20000 and c2 a permutation of 1..20000, so
+-- joining it to any table in this model on c1 or on c2 matches exactly 20000
+-- rows, once each.  Every query runs against mb16 and mplain, the same rows
+-- with and without streams, and several also against mb64 where the same
+-- ordering costs four times the streams.
+--
+-- Aliases are used throughout because the framework requires a query to use
+-- aliases for all tables or for none.
+
+
+-- ---------------------------------------------------------------------
+-- The bucketized table as the inner side of a nested loop.  Pinning c1 from
+-- the outer row is not enough to seek this index, since the bucket comes
+-- first, so the inner scan needs the derived bucket SAOP and becomes a
+-- 16-stream merge per outer row.  mplain seeks once.
+-- ---------------------------------------------------------------------
+SELECT d.c1, m.c2 FROM dj d JOIN mb16 m ON m.c1 = d.c1 WHERE d.c4 = 1 ORDER BY d.c1 LIMIT 100;
+SELECT d.c1, m.c2 FROM dj d JOIN mplain m ON m.c1 = d.c1 WHERE d.c4 = 1 ORDER BY d.c1 LIMIT 100;
+SELECT d.c1, m.c2 FROM dj d JOIN mb64 m ON m.c1 = d.c1 WHERE d.c4 = 1 ORDER BY d.c1 LIMIT 100;
+SELECT d.c1, m.c2 FROM dj d JOIN mb16 m ON m.c1 = d.c1 WHERE d.c3 = 1 ORDER BY d.c1;
+SELECT d.c1, m.c2 FROM dj d JOIN mplain m ON m.c1 = d.c1 WHERE d.c3 = 1 ORDER BY d.c1;
+
+
+-- ---------------------------------------------------------------------
+-- The same join with no filter on the outer side, so all 20000 outer rows
+-- probe.  This is where a per-parameter startup cost that the model does
+-- not charge is multiplied by 20000.
+-- ---------------------------------------------------------------------
+SELECT count(*) FROM dj d JOIN mb16 m ON m.c1 = d.c1;
+SELECT count(*) FROM dj d JOIN mplain m ON m.c1 = d.c1;
+SELECT count(*) FROM dj d JOIN mb64 m ON m.c1 = d.c1;
+SELECT d.c1, m.c4 FROM dj d JOIN mb16 m ON m.c1 = d.c1 ORDER BY d.c1 LIMIT 1000;
+SELECT d.c1, m.c4 FROM dj d JOIN mplain m ON m.c1 = d.c1 ORDER BY d.c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- Joining on the bucket's own source column.  c2 is what the bucket is
+-- generated from, so an equality on it can pin a single bucket if the
+-- planner derives the equality, and the two files eq-02 and this one meet
+-- here.  On mplain c2 is not indexed at all.
+-- ---------------------------------------------------------------------
+SELECT d.c2, m.c1 FROM dj d JOIN mb16 m ON m.c2 = d.c2 WHERE d.c4 = 1 ORDER BY d.c2 LIMIT 100;
+SELECT d.c2, m.c1 FROM dj d JOIN mplain m ON m.c2 = d.c2 WHERE d.c4 = 1 ORDER BY d.c2 LIMIT 100;
+SELECT count(*) FROM dj d JOIN mb16 m ON m.c2 = d.c2;
+SELECT count(*) FROM dj d JOIN mplain m ON m.c2 = d.c2;
+
+
+-- ---------------------------------------------------------------------
+-- Both inputs ordered on the join key, which is what a merge join wants.
+-- The merge scan supplies the ordering on the bucketized side for the price
+-- of its streams, and the question is whether that beats a hash join.
+-- ---------------------------------------------------------------------
+SELECT a.c1, b.c2 FROM mb16 a JOIN mplain b ON b.c1 = a.c1 WHERE a.c4 = 1 ORDER BY a.c1 LIMIT 1000;
+SELECT a.c1, b.c2 FROM mb16 a JOIN mb64 b ON b.c1 = a.c1 WHERE a.c4 = 1 ORDER BY a.c1 LIMIT 1000;
+SELECT a.c1, b.c2 FROM mplain a JOIN mplain b ON b.c1 = a.c1 + 1 WHERE a.c4 = 1 ORDER BY a.c1 LIMIT 1000;
+SELECT count(*) FROM mb16 a JOIN mplain b ON b.c1 = a.c1 WHERE a.c4 = 1;
+SELECT count(*) FROM mb16 a JOIN mb64 b ON b.c1 = a.c1 WHERE a.c4 = 1;
+
+
+-- ---------------------------------------------------------------------
+-- The bucketized table on the outer side, ordered, with the small table as
+-- the inner.  Here the merge's ordering carries through the join, so a
+-- LIMIT above can terminate the whole plan early if the estimate holds.
+-- ---------------------------------------------------------------------
+SELECT m.c1, d.c4 FROM mb16 m JOIN dj d ON d.c1 = m.c1 ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, d.c4 FROM mplain m JOIN dj d ON d.c1 = m.c1 ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, d.c4 FROM mb64 m JOIN dj d ON d.c1 = m.c1 ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, d.c4 FROM mb16 m JOIN dj d ON d.c1 = m.c1 ORDER BY m.c1 LIMIT 10000;
+SELECT m.c1, d.c4 FROM mplain m JOIN dj d ON d.c1 = m.c1 ORDER BY m.c1 LIMIT 10000;
+
+
+-- ---------------------------------------------------------------------
+-- Semi and anti joins, where the LIMIT above cannot be pushed through the
+-- subquery and the ordering still has to be produced.
+-- ---------------------------------------------------------------------
+SELECT m.c1, m.c2 FROM mb16 m WHERE EXISTS (SELECT 1 FROM dj d WHERE d.c1 = m.c1) ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, m.c2 FROM mplain m WHERE EXISTS (SELECT 1 FROM dj d WHERE d.c1 = m.c1) ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, m.c2 FROM mb64 m WHERE EXISTS (SELECT 1 FROM dj d WHERE d.c1 = m.c1) ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, m.c2 FROM mb16 m WHERE NOT EXISTS (SELECT 1 FROM dj d WHERE d.c1 = m.c1) ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, m.c2 FROM mplain m WHERE NOT EXISTS (SELECT 1 FROM dj d WHERE d.c1 = m.c1) ORDER BY m.c1 LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- Aggregation above the join, so no LIMIT reaches either scan.
+-- ---------------------------------------------------------------------
+SELECT d.c4, count(*), avg(m.c3) FROM dj d JOIN mb16 m ON m.c1 = d.c1 GROUP BY d.c4 ORDER BY d.c4;
+SELECT d.c4, count(*), avg(m.c3) FROM dj d JOIN mplain m ON m.c1 = d.c1 GROUP BY d.c4 ORDER BY d.c4;
+SELECT m.c1, count(*) FROM dj d JOIN mb16 m ON m.c1 = d.c1 GROUP BY m.c1 ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, count(*) FROM dj d JOIN mplain m ON m.c1 = d.c1 GROUP BY m.c1 ORDER BY m.c1 LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- Three-way joins, where a wrong scan cost has two join orders to spoil.
+-- ---------------------------------------------------------------------
+SELECT d.c1, a.c2, b.c3 FROM dj d JOIN mb16 a ON a.c1 = d.c1 JOIN mplain b ON b.c1 = d.c1 WHERE d.c4 = 1 ORDER BY d.c1 LIMIT 100;
+SELECT d.c1, a.c2, b.c3 FROM dj d JOIN mb16 a ON a.c1 = d.c1 JOIN mb64 b ON b.c1 = d.c1 WHERE d.c4 = 1 ORDER BY d.c1 LIMIT 100;
+SELECT count(*) FROM dj d JOIN mb16 a ON a.c1 = d.c1 JOIN mplain b ON b.c1 = d.c1;
+
+
+-- ---------------------------------------------------------------------
+-- The join twin of the empty-result shape: the filter matches nothing, so
+-- the join produces nothing and every early-termination discount above it
+-- is unearned.  Its matching twin follows each one.
+-- ---------------------------------------------------------------------
+SELECT m.c1, d.c4 FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE m.c7 = 50 AND m.c8 = 51 ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, d.c4 FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE m.c7 = 50 AND m.c8 = 50 ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, d.c4 FROM mplain m JOIN dj d ON d.c1 = m.c1 WHERE m.c7 = 50 AND m.c8 = 51 ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, d.c4 FROM mplain m JOIN dj d ON d.c1 = m.c1 WHERE m.c7 = 50 AND m.c8 = 50 ORDER BY m.c1 LIMIT 100;

--- a/sql/cost-validation-bucketized-v2/queries/merge-09-partitioned.sql
+++ b/sql/cost-validation-bucketized-v2/queries/merge-09-partitioned.sql
@@ -1,0 +1,106 @@
+-- Merge scan under partitioning.
+--
+-- pt holds 200000 rows range partitioned by c1 into four equal partitions,
+-- each with the same 8-bucket primary key pre-split one tablet per bucket.
+-- Ordering by c1 across the whole table therefore needs a merge inside each
+-- partition and an Append or MergeAppend across them, so the streams the
+-- executor actually runs are 8 times the number of partitions the planner
+-- fails to prune.  That multiplication is invisible to a cost model that
+-- charges a flat premium per scan node.
+--
+-- Time range partitioning over a bucketized key is a natural combination,
+-- since both exist for the same reason: the partition key spreads old data
+-- off the write path and the bucket spreads the write path itself.  It is
+-- also the one place in this model where pruning can remove streams for
+-- free, so the pruned queries below are the cheap case a corrected model
+-- should still recognize as cheap.
+--
+-- Partition boundaries are c1 in [1, 50001), [50001, 100001), [100001,
+-- 150001) and [150001, 200001).
+
+
+-- ---------------------------------------------------------------------
+-- No pruning: every partition contributes 8 streams, so 32 streams answer
+-- a query whose LIMIT wants 10 rows.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM pt ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM pt ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM pt ORDER BY c1 DESC LIMIT 10;
+SELECT c1, c2 FROM pt ORDER BY c1 OFFSET 199990 LIMIT 10;
+SELECT * FROM pt ORDER BY c1 LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- Pruned to one partition, which is the same query over a quarter of the
+-- data and an eighth of the streams.  Compare each against the unpruned row
+-- above it.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM pt WHERE c1 < 50001 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM pt WHERE c1 < 50001 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM pt WHERE c1 >= 150001 ORDER BY c1 DESC LIMIT 10;
+SELECT c1, c2 FROM pt WHERE c1 BETWEEN 100001 AND 150000 ORDER BY c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- Pruned to two partitions, the intermediate point.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM pt WHERE c1 < 100001 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM pt WHERE c1 < 100001 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM pt WHERE c1 BETWEEN 50001 AND 150000 ORDER BY c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- A boundary the planner cannot use for pruning because it is on another
+-- column, so all four partitions run and the filter removes rows after the
+-- fact.  This is the same work as the unpruned block with a smaller result.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM pt WHERE c4 = 50 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM pt WHERE c4 = 50 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM pt WHERE c6 IN (1,2) ORDER BY c1 LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- Ordering by the partition key and something else, so an incremental sort
+-- or a full sort sits above the Append.
+-- ---------------------------------------------------------------------
+SELECT c1, c2, c5 FROM pt ORDER BY c1, c5 LIMIT 100;
+SELECT c1, c2, c5 FROM pt WHERE c1 < 50001 ORDER BY c1, c5 LIMIT 100;
+SELECT c1, c2 FROM pt ORDER BY c2 LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- Aggregates, where no LIMIT reaches any partition's scan.
+-- ---------------------------------------------------------------------
+SELECT count(*) FROM pt;
+SELECT count(*) FROM pt WHERE c1 < 50001;
+SELECT count(*) FROM pt WHERE c4 = 50;
+SELECT min(c1), max(c1) FROM pt;
+SELECT c4, count(*) FROM pt GROUP BY c4 ORDER BY c4;
+SELECT c1, count(*) FROM pt GROUP BY c1 ORDER BY c1 LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- Directly against one partition, bypassing the Append entirely.  This is
+-- the per-partition cost the plans above are built from.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM pt_p1 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM pt_p1 ORDER BY c1 LIMIT 1000;
+SELECT count(*) FROM pt_p1;
+
+
+-- ---------------------------------------------------------------------
+-- Joined to the small table, so partition pruning and join order interact.
+-- dj covers c1 = 1..20000, which lies entirely inside the first partition,
+-- but only the join predicate says so.
+-- ---------------------------------------------------------------------
+SELECT p.c1, d.c4 FROM pt p JOIN dj d ON d.c1 = p.c1 ORDER BY p.c1 LIMIT 100;
+SELECT p.c1, d.c4 FROM pt p JOIN dj d ON d.c1 = p.c1 WHERE p.c1 < 50001 ORDER BY p.c1 LIMIT 100;
+SELECT count(*) FROM pt p JOIN dj d ON d.c1 = p.c1;
+
+
+-- ---------------------------------------------------------------------
+-- The empty-result twin under partitioning, where four partitions each
+-- drain all eight of their streams to return nothing.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM pt WHERE c7 = 50 AND c8 = 51 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM pt WHERE c7 = 50 AND c8 = 50 ORDER BY c1 LIMIT 10;

--- a/sql/cost-validation-bucketized-v2/queries/rival-01-alt-index.sql
+++ b/sql/cost-validation-bucketized-v2/queries/rival-01-alt-index.sql
@@ -1,0 +1,113 @@
+-- The alternative-index suite: a plain ordered index on the very column the
+-- merge scan exists to order by.
+--
+-- This file is deliberately small and deliberately separate, because the
+-- configuration it tests is one the feature is not for.  A bucketized index
+-- exists because the plain range index on the same leading columns would
+-- concentrate every insert on one shard.  A deployment that has taken that
+-- trouble does not also keep the hot index, so a query that could merge over
+-- buckets and could equally read a plain (c1 asc) index is not a realistic
+-- arbitration, and an honest per-stream cost model handles it as a byproduct
+-- of getting the streams right.  It is worth covering because it does occur,
+-- in schemas that have not finished migrating and in benchmark models, and
+-- because it is the one shape where the wrong answer is unambiguous: the
+-- plain ordered index needs no streams, no merge and no sort.
+--
+-- The tables are copies with one index added, which is the only difference:
+--
+--   sa and riv     500000 identical rows, indexes on (c6, c1), (c4, c1) and
+--                  (c3, c1), and riv additionally has riv_c1 on (c1 asc)
+--   mb16 and rivb  500000 identical rows, bucketized primary key
+--                  (c0, c1, c2), and rivb additionally has rivb_c1
+--
+-- So every query below runs twice, once where the rival exists and once
+-- where it does not.  Where the plans differ, the difference is the rival
+-- index being chosen or not, and nothing else.  In the previous model this
+-- coexistence is everywhere, and it is behind regressions such as the
+-- table_split anti-join that moved from a plain (c2 asc) index to a
+-- 64-bucket index and lost its presorted key in the process.
+
+
+-- ---------------------------------------------------------------------
+-- Derived bucket SAOP against a plain ordered index for the same order.
+-- rivb should never prefer the merge here: rivb_c1 delivers c1 order with
+-- one seek and no streams.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM rivb ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM rivb ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM rivb ORDER BY c1 OFFSET 499990 LIMIT 10;
+SELECT c1, c2 FROM mb16 ORDER BY c1 OFFSET 499990 LIMIT 10;
+SELECT c1, c2 FROM rivb ORDER BY c1 DESC LIMIT 100;
+SELECT c1, c2 FROM mb16 ORDER BY c1 DESC LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- The same with a filter, where the plain index has to read and discard
+-- while the merge could in principle push the filter down per stream.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM rivb WHERE c4 = 50 ORDER BY c1 LIMIT 100;
+SELECT c1, c2 FROM mb16 WHERE c4 = 50 ORDER BY c1 LIMIT 100;
+SELECT c1, c2 FROM rivb WHERE c7 = 50 AND c8 = 51 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE c7 = 50 AND c8 = 51 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM rivb WHERE v LIKE 'zz%' ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE v LIKE 'zz%' ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- User-written IN lists against a plain ordered index.  This is the shape
+-- described as the one merge scan should not be judged on: WHERE c6 IN
+-- (...) ORDER BY c1 works without any merge if (c1 asc) exists, and avoids
+-- the sort node too, so the merge has to beat a plan with no weaknesses.
+-- ---------------------------------------------------------------------
+SELECT c1, c6 FROM riv WHERE c6 IN (1,2) ORDER BY c1 LIMIT 10;
+SELECT c1, c6 FROM sa WHERE c6 IN (1,2) ORDER BY c1 LIMIT 10;
+SELECT c1, c6 FROM riv WHERE c6 IN (1,2,3,4) ORDER BY c1 LIMIT 10;
+SELECT c1, c6 FROM sa WHERE c6 IN (1,2,3,4) ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM riv WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16) ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16) ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM riv WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64) ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64) ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM riv WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64) ORDER BY c1 LIMIT 1000;
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64) ORDER BY c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- Selectivity, which is what should decide it.  Two c6 values are a fifth
+-- of the table, so reading them through the plain (c1 asc) index means
+-- discarding four rows in five, and the merge stops being obviously wrong.
+-- Sixteen c3 values are 1.6 % and it clearly is.
+-- ---------------------------------------------------------------------
+SELECT c1, c6 FROM riv WHERE c6 IN (1,2) ORDER BY c1 LIMIT 10000;
+SELECT c1, c6 FROM sa WHERE c6 IN (1,2) ORDER BY c1 LIMIT 10000;
+SELECT c1, c3 FROM riv WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16) ORDER BY c1 OFFSET 7990 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16) ORDER BY c1 OFFSET 7990 LIMIT 10;
+SELECT c1, c3 FROM riv WHERE c3 = 500 ORDER BY c1 LIMIT 10;
+SELECT c1, c3 FROM sa WHERE c3 = 500 ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- Ordering consumers other than ORDER BY, where a lost presorted key turns
+-- an incremental sort into a full one.  That is the mechanism behind the
+-- anti-join regression this suite exists to hold.
+-- ---------------------------------------------------------------------
+SELECT c1, c2, c5 FROM riv WHERE c6 IN (1,2) ORDER BY c1, c5 LIMIT 100;
+SELECT c1, c2, c5 FROM sa WHERE c6 IN (1,2) ORDER BY c1, c5 LIMIT 100;
+SELECT c1, count(*) FROM rivb GROUP BY c1 ORDER BY c1 LIMIT 1000;
+SELECT c1, count(*) FROM mb16 GROUP BY c1 ORDER BY c1 LIMIT 1000;
+SELECT DISTINCT ON (c1) c1, c4 FROM rivb ORDER BY c1 LIMIT 100;
+SELECT DISTINCT ON (c1) c1, c4 FROM mb16 ORDER BY c1 LIMIT 100;
+SELECT r.c1, r.c2 FROM riv r WHERE NOT EXISTS (SELECT 1 FROM dj d WHERE d.c1 = r.c1 AND d.c2 = r.c2) AND r.c2 <= 150000 ORDER BY r.c1 LIMIT 50;
+SELECT s.c1, s.c2 FROM sa s WHERE NOT EXISTS (SELECT 1 FROM dj d WHERE d.c1 = s.c1 AND d.c2 = s.c2) AND s.c2 <= 150000 ORDER BY s.c1 LIMIT 50;
+
+
+-- ---------------------------------------------------------------------
+-- No ordering at all, so the rival index has nothing to offer either and
+-- both tables should reach the same plan.  This is the negative control
+-- for the file.
+-- ---------------------------------------------------------------------
+SELECT count(*) FROM riv WHERE c6 IN (1,2);
+SELECT count(*) FROM sa WHERE c6 IN (1,2);
+SELECT count(*) FROM rivb WHERE c4 = 50;
+SELECT count(*) FROM mb16 WHERE c4 = 50;

--- a/sql/cost-validation-bucketized-v2/queries/saop-01-arbitration.sql
+++ b/sql/cost-validation-bucketized-v2/queries/saop-01-arbitration.sql
@@ -1,0 +1,133 @@
+-- yb_enable_derived_saops: choosing between the path with the derived SAOP
+-- and the path without it.
+--
+-- A derived SAOP is not a query condition.  When an index key is a bucket
+-- expression, or a column generated from one, the planner fabricates
+-- "bucket IN (0 .. B-1)", which every row satisfies, purely so the index can
+-- be seeked and merged.  The condition adds no selectivity and removes no
+-- rows.  What it adds is a path: an index that could not be used at all
+-- without a predicate on its leading key becomes usable, ordered, and
+-- competitive.
+--
+-- Derived SAOPs only attach to merge scan index paths, so this GUC cannot
+-- regress a plan that has no merge in it.  The planner keeps the path without
+-- the derivation alongside the one with it and takes the cheaper, which makes
+-- every query here a cost comparison and nothing else.  A wrong answer is a
+-- cost model error, and some of the errors this file finds will not be
+-- specific to merge scan at all: an index scan with a 100 % passing condition
+-- competing against a sequential scan is the general symptom in
+-- yugabyte/yugabyte-db#32317.
+--
+-- Each block pairs a query where the derivation clearly earns its cost with
+-- one where it clearly does not, and puts the ambiguous shapes between them.
+-- mplain twins run the same query where no derivation is possible, so the
+-- pair brackets what the derived path is worth.
+
+
+-- ---------------------------------------------------------------------
+-- The derivation earns it: ordered, small LIMIT, no other ordered path.
+-- Without the derived SAOP these have to sort the whole table.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb64 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mw16 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mplain ORDER BY c1 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- The derivation cannot earn anything: nothing above the scan wants an
+-- order, so the only thing a merge path can do is cost more.  A derived
+-- SAOP appearing in any of these is the yugabyte/yugabyte-db#32317 symptom,
+-- an index scan preferred on the strength of a condition that passes every
+-- row.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb16 WHERE c4 = 50;
+SELECT c1, c2 FROM mplain WHERE c4 = 50;
+SELECT c1, c2 FROM mb16 WHERE sign(c1 - c2) = 1;
+SELECT c1, c2 FROM mplain WHERE sign(c1 - c2) = 1;
+SELECT c1, c2, v FROM mw16 WHERE sign(c1 - c2) = 1;
+SELECT count(*) FROM mb16 WHERE sign(c1 - c2) = 1;
+SELECT count(*) FROM mplain WHERE sign(c1 - c2) = 1;
+SELECT c1, c2 FROM mb16 WHERE c5 > 250000;
+SELECT c1, c2 FROM mplain WHERE c5 > 250000;
+
+
+-- ---------------------------------------------------------------------
+-- Ordered, but the filter is one the storage layer has to evaluate on every
+-- row, so neither path terminates early and the merge's streams are pure
+-- overhead on top of a full read.  This is the single-table form of the
+-- #32317 join shape.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb16 WHERE sign(c1 - c2) = 1 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mplain WHERE sign(c1 - c2) = 1 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb64 WHERE sign(c1 - c2) = 1 ORDER BY c1 LIMIT 10;
+SELECT c1, c2, v FROM mw16 WHERE sign(c1 - c2) = 1 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mn16 WHERE sign(c1 - c2) = 1 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE sign(c1 - c2) = 1 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mplain WHERE sign(c1 - c2) = 1 ORDER BY c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- Ordered with no LIMIT, so the merge saves a sort and nothing else.  The
+-- sort it saves is over 500000 rows, which is a real saving, and the
+-- question is only whether it is worth 16 or 64 streams.
+-- ---------------------------------------------------------------------
+SELECT c1 FROM mb16 ORDER BY c1;
+SELECT c1 FROM mb64 ORDER BY c1;
+SELECT c1 FROM mplain ORDER BY c1;
+SELECT c1, c2 FROM mb16 ORDER BY c1 OFFSET 499990 LIMIT 10;
+SELECT c1, c2 FROM mb64 ORDER BY c1 OFFSET 499990 LIMIT 10;
+SELECT c1, c2 FROM mplain ORDER BY c1 OFFSET 499990 LIMIT 10;
+
+
+-- ---------------------------------------------------------------------
+-- The projection decides whether the merge path is covering.  Selecting
+-- only key columns keeps it an index only scan, and adding c4 forces a heap
+-- fetch per row on top of the streams.
+-- ---------------------------------------------------------------------
+SELECT c1 FROM mb16 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 1000;
+SELECT c1, c2, c4 FROM mb16 ORDER BY c1 LIMIT 1000;
+SELECT * FROM mb16 ORDER BY c1 LIMIT 1000;
+SELECT c1 FROM mplain ORDER BY c1 LIMIT 1000;
+SELECT c1, c2, c4 FROM mplain ORDER BY c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- Ordering consumed by something other than ORDER BY.  The derivation is
+-- what makes the ordered input available, so these are the same arbitration
+-- with a different buyer.
+-- ---------------------------------------------------------------------
+SELECT c1, count(*) FROM mb16 GROUP BY c1 ORDER BY c1 LIMIT 100;
+SELECT c1, count(*) FROM mplain GROUP BY c1 ORDER BY c1 LIMIT 100;
+SELECT DISTINCT ON (c1) c1, c4 FROM mb16 ORDER BY c1 LIMIT 100;
+SELECT DISTINCT ON (c1) c1, c4 FROM mplain ORDER BY c1 LIMIT 100;
+SELECT c4, count(*) FROM mb16 GROUP BY c4 ORDER BY c4;
+SELECT c4, count(*) FROM mplain GROUP BY c4 ORDER BY c4;
+
+
+-- ---------------------------------------------------------------------
+-- Ordering by a column the bucketized key does not lead with, so the
+-- derived SAOP cannot deliver it and no merge should appear.  These are the
+-- negative control for the whole file.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb16 ORDER BY c4 LIMIT 100;
+SELECT c1, c2 FROM mb16 ORDER BY c5 LIMIT 100;
+SELECT c1, c2 FROM mplain ORDER BY c5 LIMIT 100;
+SELECT c1, c2 FROM mb16 ORDER BY c2 LIMIT 100;
+SELECT c1, c2 FROM mplain ORDER BY c2 LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- The derivation on an expression index rather than a generated column.
+-- dex_c1c2's leading key is the bucket expression itself, which reaches the
+-- derivation through a different code path, and dex has a plain primary key
+-- on c2 as the alternative.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM dex ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM dex ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM dex ORDER BY c1 OFFSET 299990 LIMIT 10;
+SELECT c1, c2 FROM dex WHERE c4 = 50 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM dex WHERE sign(c1 - c2) = 1 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM dex WHERE sign(c1 - c2) = 1;
+SELECT count(*) FROM dex;

--- a/sql/cost-validation-bucketized-v2/queries/saop-02-user-vs-derived.sql
+++ b/sql/cost-validation-bucketized-v2/queries/saop-02-user-vs-derived.sql
@@ -1,0 +1,102 @@
+-- yb_enable_derived_saops: the user-written form of the condition the
+-- planner derives.
+--
+-- "bucket IN (0 .. B-1)" is the same predicate whether the planner fabricates
+-- it or the user types it, but the two take different routes to a row
+-- estimate.  The derived form is not a restriction clause and never goes
+-- through clause selectivity, so the scan keeps the full row count.  The
+-- written form does go through it, and lands on a floating point boundary:
+-- upstream's scalararraysel computes the correct disjoint sum for an equality
+-- IN list but accepts it only if it is at most exactly 1.0, and MCV
+-- frequencies are stored as float4, so a full-domain IN sums to 1.0 give or
+-- take a few 1e-8 depending on how the ANALYZE sample rounded.  Landing above
+-- it by 4e-9 silently switches the estimate to the independence formula,
+-- about 0.64 of the table at 16 buckets.  That is yugabyte/yugabyte-db#33251,
+-- and it means the same query can plan differently after two ANALYZE runs on
+-- identical data.
+--
+-- Every pair below is a written IN list against the identical query with the
+-- predicate removed so the planner derives it.  A cost difference inside a
+-- pair is an estimation difference, not a plan-mechanics difference, and the
+-- partial lists are the control: they are not on the 1.0 boundary and should
+-- be estimated consistently.
+--
+-- These are the only queries in the model that write a full-domain IN on a
+-- bucket column.  Everywhere else the derivation is left to the planner,
+-- because the written form is both unrealistic and unstable.
+
+
+-- ---------------------------------------------------------------------
+-- Full domain written out against left to the planner, at 16 buckets.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb16 WHERE c0 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15) ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 10;
+SELECT c1, c2 FROM mb16 WHERE c0 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15) ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mb16 ORDER BY c1 LIMIT 1000;
+SELECT count(*) FROM mb16 WHERE c0 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15);
+SELECT count(*) FROM mb16;
+
+
+-- ---------------------------------------------------------------------
+-- The same at 2 and at 4 buckets, where the disjoint sum has fewer rounded
+-- terms and should be less likely to cross 1.0.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb2 WHERE c0 IN (0,1) ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mb2 ORDER BY c1 LIMIT 1000;
+SELECT count(*) FROM mb2 WHERE c0 IN (0,1);
+SELECT c1, c2 FROM mb4 WHERE c0 IN (0,1,2,3) ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mb4 ORDER BY c1 LIMIT 1000;
+SELECT count(*) FROM mb4 WHERE c0 IN (0,1,2,3);
+
+
+-- ---------------------------------------------------------------------
+-- And at 64 buckets, the most rounded terms in the model and the most
+-- likely to flip.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb64 WHERE c0 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63) ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mb64 ORDER BY c1 LIMIT 1000;
+SELECT count(*) FROM mb64 WHERE c0 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63);
+SELECT count(*) FROM mb64;
+
+
+-- ---------------------------------------------------------------------
+-- Partial lists, the control.  A list short of the full domain is a normal
+-- selectivity estimate nowhere near the 1.0 boundary, and it also produces
+-- fewer streams than the derivation would, which no derived form can do.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM mb16 WHERE c0 IN (0,1) ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mb16 WHERE c0 IN (0,1,2,3) ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mb16 WHERE c0 IN (0,1,2,3,4,5,6,7) ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM mb16 WHERE c0 = 0 ORDER BY c1 LIMIT 1000;
+SELECT count(*) FROM mb16 WHERE c0 IN (0,1,2,3);
+SELECT count(*) FROM mb16 WHERE c0 = 0;
+
+
+-- ---------------------------------------------------------------------
+-- A written list that covers the domain but says so twice.  The elements
+-- are not distinct, which is the case the 1.0 guard actually exists to
+-- catch, so this one is expected to fall back and is the honest comparison
+-- for what the guard is for.
+-- ---------------------------------------------------------------------
+SELECT count(*) FROM mb4 WHERE c0 IN (0,1,2,3,0,1,2,3);
+SELECT c1, c2 FROM mb4 WHERE c0 IN (0,1,2,3,0,1,2,3) ORDER BY c1 LIMIT 1000;
+
+
+-- ---------------------------------------------------------------------
+-- The written form combined with a second merge-eligible IN list, so the
+-- estimate error and the stream product interact.
+-- ---------------------------------------------------------------------
+SELECT c1, c2 FROM ms16 WHERE c0 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15) AND c6 IN (1,2) ORDER BY c1 LIMIT 1000;
+SELECT c1, c2 FROM ms16 WHERE c6 IN (1,2) ORDER BY c1 LIMIT 1000;
+SELECT count(*) FROM ms16 WHERE c0 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15) AND c6 IN (1,2);
+SELECT count(*) FROM ms16 WHERE c6 IN (1,2);
+
+
+-- ---------------------------------------------------------------------
+-- The estimate feeding a join, where a 0.64x scan estimate propagates into
+-- the join sizing and the join order.
+-- ---------------------------------------------------------------------
+SELECT m.c1, d.c4 FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE m.c0 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15) ORDER BY m.c1 LIMIT 100;
+SELECT m.c1, d.c4 FROM mb16 m JOIN dj d ON d.c1 = m.c1 ORDER BY m.c1 LIMIT 100;
+SELECT count(*) FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE m.c0 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15);
+SELECT count(*) FROM mb16 m JOIN dj d ON d.c1 = m.c1;

--- a/sql/cost-validation-bucketized-v2/queries/saop-03-join-order-flip.sql
+++ b/sql/cost-validation-bucketized-v2/queries/saop-03-join-order-flip.sql
@@ -1,0 +1,96 @@
+-- yb_enable_derived_saops: the derivation flipping a join order.
+--
+-- This is the shape in yugabyte/yugabyte-db#32317, reproduced on this model's
+-- tables.  The mechanism: a wide bucketized table carries a filter the
+-- storage layer must evaluate row by row and nothing an index can seek on, so
+-- without the derivation the only way to use its index is as the inner side
+-- of a batched nested loop, driven by the small table.  The derived SAOP
+-- gives that table an index condition it did not have, which makes an ordered
+-- index scan over it possible, which makes it a candidate for the outer side.
+-- The planner then reverses the join order and reads the wide table through
+-- 16 streams while filtering nearly everything out.
+--
+-- Verified on this schema: with the derivation the plan is a batched nested
+-- loop whose outer is a 16-stream merge scan over mw16 with the storage
+-- filter attached, and without it the plan drives from dj and reaches mw16
+-- through a derived-equality index condition on the inner side.  The
+-- estimates differ by more than the true costs do, which is the point.
+--
+-- The filters here are deliberately opaque.  sign(c1 - c2) = 1 is true for
+-- about half the rows and the planner cannot see that, position() and
+-- length() on v likewise, so in every query the planner is choosing a join
+-- order on an estimate it has no basis for.  That is exactly the situation a
+-- new path being available is most likely to spoil.
+--
+-- Aliases are used throughout, as the framework requires for join queries.
+
+
+-- ---------------------------------------------------------------------
+-- The reported shape.  Two-column join, opaque filter on the wide side,
+-- ORDER BY on the join columns.
+-- ---------------------------------------------------------------------
+SELECT w.c1, w.c2, w.v, d.c3 FROM mw16 w JOIN dj d ON d.c1 = w.c1 AND d.c2 = w.c2 WHERE sign(w.c1 - w.c2) = 1 ORDER BY w.c1, w.c2;
+SELECT w.c1, w.c2, w.v, d.c3 FROM mw16 w JOIN dj d ON d.c1 = w.c1 AND d.c2 = w.c2 ORDER BY w.c1, w.c2;
+SELECT w.c1, w.c2, d.c3 FROM mw16 w JOIN dj d ON d.c1 = w.c1 AND d.c2 = w.c2 WHERE sign(w.c1 - w.c2) = 1 ORDER BY w.c1, w.c2;
+SELECT n.c1, n.c2, n.v, d.c3 FROM mn16 n JOIN dj d ON d.c1 = n.c1 AND d.c2 = n.c2 WHERE sign(n.c1 - n.c2) = 1 ORDER BY n.c1, n.c2;
+SELECT p.c1, p.c2, p.v, d.c3 FROM mplain p JOIN dj d ON d.c1 = p.c1 AND d.c2 = p.c2 WHERE sign(p.c1 - p.c2) = 1 ORDER BY p.c1, p.c2;
+
+
+-- ---------------------------------------------------------------------
+-- The same with a LIMIT, so the flipped plan also carries an early
+-- termination discount it cannot honour: the filter passes about half the
+-- rows but the ordering is on the outer side, so the LIMIT does stop the
+-- scan, and the comparison is about how much was read to get there.
+-- ---------------------------------------------------------------------
+SELECT w.c1, w.c2, w.v, d.c3 FROM mw16 w JOIN dj d ON d.c1 = w.c1 AND d.c2 = w.c2 WHERE sign(w.c1 - w.c2) = 1 ORDER BY w.c1, w.c2 LIMIT 100;
+SELECT w.c1, w.c2, w.v, d.c3 FROM mw16 w JOIN dj d ON d.c1 = w.c1 AND d.c2 = w.c2 ORDER BY w.c1, w.c2 LIMIT 100;
+SELECT n.c1, n.c2, d.c3 FROM mn16 n JOIN dj d ON d.c1 = n.c1 AND d.c2 = n.c2 WHERE sign(n.c1 - n.c2) = 1 ORDER BY n.c1, n.c2 LIMIT 100;
+SELECT p.c1, p.c2, d.c3 FROM mplain p JOIN dj d ON d.c1 = p.c1 AND d.c2 = p.c2 WHERE sign(p.c1 - p.c2) = 1 ORDER BY p.c1, p.c2 LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- Single column join, where the derived path on the bucketized side is
+-- ordered on the join key and a merge join becomes possible as well.
+-- ---------------------------------------------------------------------
+SELECT m.c1, d.c3 FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE sign(m.c1 - m.c2) = 1 ORDER BY m.c1;
+SELECT m.c1, d.c3 FROM mb16 m JOIN dj d ON d.c1 = m.c1 ORDER BY m.c1;
+SELECT m.c1, d.c3 FROM mb64 m JOIN dj d ON d.c1 = m.c1 WHERE sign(m.c1 - m.c2) = 1 ORDER BY m.c1;
+SELECT p.c1, d.c3 FROM mplain p JOIN dj d ON d.c1 = p.c1 WHERE sign(p.c1 - p.c2) = 1 ORDER BY p.c1;
+SELECT m.c1, d.c3 FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE sign(m.c1 - m.c2) = 1 ORDER BY m.c1 LIMIT 100;
+SELECT p.c1, d.c3 FROM mplain p JOIN dj d ON d.c1 = p.c1 WHERE sign(p.c1 - p.c2) = 1 ORDER BY p.c1 LIMIT 100;
+
+
+-- ---------------------------------------------------------------------
+-- Opaque filters of other kinds, so the finding does not depend on one
+-- expression being unusually badly estimated.  v is a constant 64 or 4096
+-- characters, so length(v) > 8 passes every row and position('zzz' in v)
+-- passes none, and the planner's estimate for both is a default.
+-- ---------------------------------------------------------------------
+SELECT w.c1, w.c2, d.c3 FROM mw16 w JOIN dj d ON d.c1 = w.c1 WHERE length(w.v) > 8 ORDER BY w.c1;
+SELECT w.c1, w.c2, d.c3 FROM mw16 w JOIN dj d ON d.c1 = w.c1 WHERE position('zzz' in w.v) > 0 ORDER BY w.c1;
+SELECT m.c1, m.c2, d.c3 FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE length(m.v) > 8 ORDER BY m.c1;
+SELECT m.c1, m.c2, d.c3 FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE position('zzz' in m.v) > 0 ORDER BY m.c1;
+SELECT p.c1, p.c2, d.c3 FROM mplain p JOIN dj d ON d.c1 = p.c1 WHERE length(p.v) > 8 ORDER BY p.c1;
+SELECT p.c1, p.c2, d.c3 FROM mplain p JOIN dj d ON d.c1 = p.c1 WHERE position('zzz' in p.v) > 0 ORDER BY p.c1;
+
+
+-- ---------------------------------------------------------------------
+-- No ORDER BY at all, so the derived path has nothing to sell and the join
+-- order should be decided on scan costs alone.  A flip here would be the
+-- purest form of the #32317 symptom.
+-- ---------------------------------------------------------------------
+SELECT w.c1, w.c2, d.c3 FROM mw16 w JOIN dj d ON d.c1 = w.c1 AND d.c2 = w.c2 WHERE sign(w.c1 - w.c2) = 1;
+SELECT m.c1, d.c3 FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE sign(m.c1 - m.c2) = 1;
+SELECT p.c1, d.c3 FROM mplain p JOIN dj d ON d.c1 = p.c1 WHERE sign(p.c1 - p.c2) = 1;
+SELECT count(*) FROM mw16 w JOIN dj d ON d.c1 = w.c1 WHERE sign(w.c1 - w.c2) = 1;
+SELECT count(*) FROM mb16 m JOIN dj d ON d.c1 = m.c1 WHERE sign(m.c1 - m.c2) = 1;
+SELECT count(*) FROM mplain p JOIN dj d ON d.c1 = p.c1 WHERE sign(p.c1 - p.c2) = 1;
+
+
+-- ---------------------------------------------------------------------
+-- Three tables, so a flipped scan choice has more join orders to spoil and
+-- the wide table can end up anywhere in the plan.
+-- ---------------------------------------------------------------------
+SELECT w.c1, d.c3, m.c4 FROM mw16 w JOIN dj d ON d.c1 = w.c1 JOIN mb16 m ON m.c1 = w.c1 WHERE sign(w.c1 - w.c2) = 1 ORDER BY w.c1;
+SELECT w.c1, d.c3, m.c4 FROM mw16 w JOIN dj d ON d.c1 = w.c1 JOIN mplain m ON m.c1 = w.c1 WHERE sign(w.c1 - w.c2) = 1 ORDER BY w.c1;
+SELECT count(*) FROM mw16 w JOIN dj d ON d.c1 = w.c1 JOIN mb16 m ON m.c1 = w.c1 WHERE sign(w.c1 - w.c2) = 1;


### PR DESCRIPTION
The bucketized-index feature is three planner GUCs that default to on and fail in different ways, and cost-validation-bucketized treats them as one thing.  Its tables carry bucketized and plain indexes over the same columns, its query files mix all three GUCs together, and it has no controlled bucket-count sweep, so a finding cannot be attributed and the one measurement the merge scan cost model most needs is missing.

Add a sibling model where each query file targets exactly one GUC and the file name says which.  merge-* covers yb_max_merge_scan_streams, the main effort, whose cost model today is a 1.02 placeholder (yugabyte/yugabyte-db#29078) that charges the same for 2 streams as for
64.  saop-* covers yb_enable_derived_saops, which since D51960 can only attach to merge scan index paths, so what is left to test is the cost comparison between the path with the derivation and the path without. eq-* covers yb_enable_derived_equalities and its open defects, #31164 where no non-derived path is generated and #31354 where the derived expression is never const-folded.

The schema follows a hot-shard rule.  A bucketized index exists because the plain range index on the same leading columns would put every insert on one shard, and a deployment that has taken that trouble does not keep the hot index, so where a bucketized entity orders by c1 no plain index leads with c1 on that table.  Plain indexes on non-monotone columns stay, because they are what a real schema has and they give the CBO a genuine rival.  Two tables break the rule on purpose and hold the whole of rival-01, which is thin because that arbitration is not what the feature is for.

The instrument for merge scan is a bucket-count sweep: mb2, mb4, mb16 and mb64 hold identical rows and differ only in the modulus, with mplain holding the same rows unbucketized as the floor.  Every bucketized entity is pre-split one tablet per bucket so measurements stay off #33247, and mn16 against mw16 isolates row width from everything else.

Query files contain no SET at all, so a feature-off against feature-on comparison is a matter of database settings between collect runs.

Verified against a single-node RF1 cluster on release binaries at 5eae1e456c2198a7a50b6db33cb225bee674e17b with yb_enable_cbo on: the DDL and load apply cleanly, every pre-split entity reports its intended tablet count through yb_table_properties, and all 665 queries pass both EXPLAIN and EXPLAIN ANALYZE with no errors in 74 seconds of wall time for one pass.  336 produce a merge scan, 70 a derived-equality index condition and 26 a bitmap plan.  Every data fact the comments assert was checked against the loaded data.  The instrument reproduces the #32317 join-order flip, shows mb64 scanning 64000 rows where mplain scans 1000 for the same LIMIT 1000 result at costs within 2 percent of each other, and shows the CBO preferring a 16-stream merge that scans 160 rows over a covering plain index that scans 10.

The existing cost-validation-bucketized is left untouched.